### PR TITLE
Make all log options available

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,12 @@ Available targets:
 | instance_count | Number of data nodes in the cluster | string | `4` | no |
 | instance_type | Elasticsearch instance type for data nodes in the cluster | string | `t2.small.elasticsearch` | no |
 | kibana_subdomain_name | The name of the subdomain for Kibana in the DNS zone (_e.g._ `kibana`, `ui`, `ui-es`, `search-ui`, `kibana.elasticsearch`) | string | `kibana` | no |
-| log_publishing_cloudwatch_log_group_arn | ARN of the Cloudwatch log group to which log needs to be published | string | `` | no |
-| log_publishing_enabled | Specifies whether log publishing option is enabled or not | string | `false` | no |
-| log_publishing_log_type | A type of Elasticsearch log. Valid values: INDEX_SLOW_LOGS, SEARCH_SLOW_LOGS | string | `SEARCH_SLOW_LOGS` | no |
+| log_publishing_index_cloudwatch_log_group_arn | ARN of the Cloudwatch log group to which log needs to be published for INDEX_SLOW_LOGS | string | `` | no |
+| log_publishing_search_cloudwatch_log_group_arn | ARN of the Cloudwatch log group to which log needs to be published for SEARCH_SLOW_LOGS | string | `` | no |
+| log_publishing_application_cloudwatch_log_group_arn | ARN of the Cloudwatch log group to which log needs to be published for ES_APPLICATION_LOGS | string | `` | no |
+| log_publishing_index_enabled | Specifies whether log publishing option for index slow logs is enabled or not | string | `false` | no |
+| log_publishing_search_enabled | Specifies whether log publishing option for search slow logs is enabled or not | string | `false` | no |
+| log_publishing_application_enabled | Specifies whether log publishing option for application logs is enabled or not | string | `false` | no |
 | name | Name of the application | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | security_groups | List of security group IDs to be allowed to connect to the cluster | list | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ Available targets:
 | instance_count | Number of data nodes in the cluster | string | `4` | no |
 | instance_type | Elasticsearch instance type for data nodes in the cluster | string | `t2.small.elasticsearch` | no |
 | kibana_subdomain_name | The name of the subdomain for Kibana in the DNS zone (_e.g._ `kibana`, `ui`, `ui-es`, `search-ui`, `kibana.elasticsearch`) | string | `kibana` | no |
-| log_publishing_index_cloudwatch_log_group_arn | ARN of the Cloudwatch log group to which log needs to be published for INDEX_SLOW_LOGS | string | `` | no |
-| log_publishing_search_cloudwatch_log_group_arn | ARN of the Cloudwatch log group to which log needs to be published for SEARCH_SLOW_LOGS | string | `` | no |
-| log_publishing_application_cloudwatch_log_group_arn | ARN of the Cloudwatch log group to which log needs to be published for ES_APPLICATION_LOGS | string | `` | no |
+| log_publishing_index_cloudwatch_log_group_arn | ARN of the CloudWatch log group to which log needs to be published for INDEX_SLOW_LOGS | string | `` | no |
+| log_publishing_search_cloudwatch_log_group_arn | ARN of the CloudWatch log group to which log needs to be published for SEARCH_SLOW_LOGS | string | `` | no |
+| log_publishing_application_cloudwatch_log_group_arn | ARN of the CloudWatch log group to which log needs to be published for ES_APPLICATION_LOGS | string | `` | no |
 | log_publishing_index_enabled | Specifies whether log publishing option for index slow logs is enabled or not | string | `false` | no |
 | log_publishing_search_enabled | Specifies whether log publishing option for search slow logs is enabled or not | string | `false` | no |
 | log_publishing_application_enabled | Specifies whether log publishing option for application logs is enabled or not | string | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -25,9 +25,9 @@
 | instance_count | Number of data nodes in the cluster | string | `4` | no |
 | instance_type | Elasticsearch instance type for data nodes in the cluster | string | `t2.small.elasticsearch` | no |
 | kibana_subdomain_name | The name of the subdomain for Kibana in the DNS zone (_e.g._ `kibana`, `ui`, `ui-es`, `search-ui`, `kibana.elasticsearch`) | string | `kibana` | no |
-| log_publishing_index_cloudwatch_log_group_arn | ARN of the Cloudwatch log group to which log needs to be published for INDEX_SLOW_LOGS | string | `` | no |
-| log_publishing_search_cloudwatch_log_group_arn | ARN of the Cloudwatch log group to which log needs to be published for SEARCH_SLOW_LOGS | string | `` | no |
-| log_publishing_application_cloudwatch_log_group_arn | ARN of the Cloudwatch log group to which log needs to be published for ES_APPLICATION_LOGS | string | `` | no |
+| log_publishing_index_cloudwatch_log_group_arn | ARN of the CloudWatch log group to which log needs to be published for INDEX_SLOW_LOGS | string | `` | no |
+| log_publishing_search_cloudwatch_log_group_arn | ARN of the CloudWatch log group to which log needs to be published for SEARCH_SLOW_LOGS | string | `` | no |
+| log_publishing_application_cloudwatch_log_group_arn | ARN of the CloudWatch log group to which log needs to be published for ES_APPLICATION_LOGS | string | `` | no |
 | log_publishing_index_enabled | Specifies whether log publishing option for index slow logs is enabled or not | string | `false` | no |
 | log_publishing_search_enabled | Specifies whether log publishing option for search slow logs is enabled or not | string | `false` | no |
 | log_publishing_application_enabled | Specifies whether log publishing option for application logs is enabled or not | string | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -25,9 +25,12 @@
 | instance_count | Number of data nodes in the cluster | string | `4` | no |
 | instance_type | Elasticsearch instance type for data nodes in the cluster | string | `t2.small.elasticsearch` | no |
 | kibana_subdomain_name | The name of the subdomain for Kibana in the DNS zone (_e.g._ `kibana`, `ui`, `ui-es`, `search-ui`, `kibana.elasticsearch`) | string | `kibana` | no |
-| log_publishing_cloudwatch_log_group_arn | ARN of the Cloudwatch log group to which log needs to be published | string | `` | no |
-| log_publishing_enabled | Specifies whether log publishing option is enabled or not | string | `false` | no |
-| log_publishing_log_type | A type of Elasticsearch log. Valid values: INDEX_SLOW_LOGS, SEARCH_SLOW_LOGS | string | `SEARCH_SLOW_LOGS` | no |
+| log_publishing_index_cloudwatch_log_group_arn | ARN of the Cloudwatch log group to which log needs to be published for INDEX_SLOW_LOGS | string | `` | no |
+| log_publishing_search_cloudwatch_log_group_arn | ARN of the Cloudwatch log group to which log needs to be published for SEARCH_SLOW_LOGS | string | `` | no |
+| log_publishing_application_cloudwatch_log_group_arn | ARN of the Cloudwatch log group to which log needs to be published for ES_APPLICATION_LOGS | string | `` | no |
+| log_publishing_index_enabled | Specifies whether log publishing option for index slow logs is enabled or not | string | `false` | no |
+| log_publishing_search_enabled | Specifies whether log publishing option for search slow logs is enabled or not | string | `false` | no |
+| log_publishing_application_enabled | Specifies whether log publishing option for application logs is enabled or not | string | `false` | no |
 | name | Name of the application | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | security_groups | List of security group IDs to be allowed to connect to the cluster | list | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -95,9 +95,21 @@ resource "aws_elasticsearch_domain" "default" {
   }
 
   log_publishing_options {
-    enabled                  = "${var.log_publishing_enabled }"
-    log_type                 = "${var.log_publishing_log_type}"
-    cloudwatch_log_group_arn = "${var.log_publishing_cloudwatch_log_group_arn}"
+    enabled                  = "${var.log_publishing_index_enabled }"
+    log_type                 = "INDEX_SLOW_LOGS"
+    cloudwatch_log_group_arn = "${var.log_publishing_index_cloudwatch_log_group_arn}"
+  }
+
+  log_publishing_options {
+    enabled                  = "${var.log_publishing_search_enabled }"
+    log_type                 = "SEARCH_SLOW_LOGS"
+    cloudwatch_log_group_arn = "${var.log_publishing_search_cloudwatch_log_group_arn}"
+  }
+
+  log_publishing_options {
+    enabled                  = "${var.log_publishing_application_enabled }"
+    log_type                 = "ES_APPLICATION_LOGS"
+    cloudwatch_log_group_arn = "${var.log_publishing_application_cloudwatch_log_group_arn}"
   }
 
   tags = "${module.label.tags}"

--- a/variables.tf
+++ b/variables.tf
@@ -149,19 +149,19 @@ variable "log_publishing_application_enabled" {
 variable "log_publishing_index_cloudwatch_log_group_arn" {
   type        = "string"
   default     = ""
-  description = "ARN of the Cloudwatch log group to which log for INDEX_SLOW_LOGS needs to be published"
+  description = "ARN of the CloudWatch log group to which log for INDEX_SLOW_LOGS needs to be published"
 }
 
 variable "log_publishing_search_cloudwatch_log_group_arn" {
   type        = "string"
   default     = ""
-  description = "ARN of the Cloudwatch log group to which log for SEARCH_SLOW_LOGS  needs to be published"
+  description = "ARN of the CloudWatch log group to which log for SEARCH_SLOW_LOGS  needs to be published"
 }
 
 variable "log_publishing_application_cloudwatch_log_group_arn" {
   type        = "string"
   default     = ""
-  description = "ARN of the Cloudwatch log group to which log for ES_APPLICATION_LOGS needs to be published"
+  description = "ARN of the CloudWatch log group to which log for ES_APPLICATION_LOGS needs to be published"
 }
 
 variable "automated_snapshot_start_hour" {

--- a/variables.tf
+++ b/variables.tf
@@ -128,22 +128,40 @@ variable "encrypt_at_rest_kms_key_id" {
   description = "The KMS key id to encrypt the Elasticsearch domain with. If not specified, then it defaults to using the AWS/Elasticsearch service KMS key"
 }
 
-variable "log_publishing_enabled" {
+variable "log_publishing_index_enabled" {
   type        = "string"
   default     = "false"
-  description = "Specifies whether log publishing option is enabled or not"
+  description = "Specifies whether log publishing option for INDEX_SLOW_LOGS is enabled or not"
 }
 
-variable "log_publishing_log_type" {
+variable "log_publishing_search_enabled" {
   type        = "string"
-  default     = "SEARCH_SLOW_LOGS"
-  description = "A type of Elasticsearch log. Valid values: INDEX_SLOW_LOGS, SEARCH_SLOW_LOGS"
+  default     = "false"
+  description = "Specifies whether log publishing option for SEARCH_SLOW_LOGS is enabled or not"
 }
 
-variable "log_publishing_cloudwatch_log_group_arn" {
+variable "log_publishing_application_enabled" {
+  type        = "string"
+  default     = "false"
+  description = "Specifies whether log publishing option for ES_APPLICATION_LOGS is enabled or not"
+}
+
+variable "log_publishing_index_cloudwatch_log_group_arn" {
   type        = "string"
   default     = ""
-  description = "ARN of the Cloudwatch log group to which log needs to be published"
+  description = "ARN of the Cloudwatch log group to which log for INDEX_SLOW_LOGS needs to be published"
+}
+
+variable "log_publishing_search_cloudwatch_log_group_arn" {
+  type        = "string"
+  default     = ""
+  description = "ARN of the Cloudwatch log group to which log for SEARCH_SLOW_LOGS  needs to be published"
+}
+
+variable "log_publishing_application_cloudwatch_log_group_arn" {
+  type        = "string"
+  default     = ""
+  description = "ARN of the Cloudwatch log group to which log for ES_APPLICATION_LOGS needs to be published"
 }
 
 variable "automated_snapshot_start_hour" {


### PR DESCRIPTION
# What
* All available log options are individually configurable and can be enabled or disabled (default) 
* The cloudwatch log group arn can be reused for each logging type or a separate one can be used.

# Why
* To be able to choose any/all or none logging type instead of being bound to only one

Fixes #7 