### PR TITLE
Add IAM role for access to ES

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,17 @@ module "label" {
   tags       = "${var.tags}"
 }
 
+module "user_label" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.5.3"
+  enabled    = "${var.enabled}"
+  namespace  = "${var.namespace}"
+  name       = "${var.name}"
+  stage      = "${var.stage}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${concat(var.attributes, list("user"))}"
+  tags       = "${var.tags}"
+}
+
 resource "aws_security_group" "default" {
   count       = "${var.enabled == "true" ? 1 : 0}"
   vpc_id      = "${var.vpc_id}"
@@ -60,9 +71,10 @@ resource "aws_iam_service_linked_role" "default" {
 # Role that pods can assume for access to elasticsearch and kibana
 resource "aws_iam_role" "elasticsearch_user" {
   count              = "${var.enabled == "true" ? 1 : 0}"
-  name               = "${module.label.id}-user"
+  name               = "${module.user_label.id}"
   assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
-  description        = "User of Elasticserach ${module.label.id} cluster"
+  description        = "IAM Role to assume to access the Elasticsearch ${module.label.id} cluster"
+  tags               = "${module.user_label.tags}"
 }
 
 data "aws_iam_policy_document" "assume_role" {

--- a/output.tf
+++ b/output.tf
@@ -32,3 +32,13 @@ output "kibana_hostname" {
   value       = "${module.kibana_hostname.hostname}"
   description = "Kibana hostname"
 }
+
+output "elasticsearch_user_iam_role_name" {
+  value       = "${join(",", aws_iam_role.elasticsearch_user.*.name)}"
+  description = "IAM name of role for Elasticsearch users"
+}
+
+output "elasticsearch_user_iam_role_arn" {
+  value       = "${join(",",aws_iam_role.elasticsearch_user.*.arn)}"
+  description = "IAM ARN of role for Elasticsearch users"
+}

--- a/output.tf
+++ b/output.tf
@@ -35,10 +35,10 @@ output "kibana_hostname" {
 
 output "elasticsearch_user_iam_role_name" {
   value       = "${join(",", aws_iam_role.elasticsearch_user.*.name)}"
-  description = "IAM name of role for Elasticsearch users"
+  description = "The name of the IAM role to allow access to Elasticsearch cluster"
 }
 
 output "elasticsearch_user_iam_role_arn" {
   value       = "${join(",",aws_iam_role.elasticsearch_user.*.arn)}"
-  description = "IAM ARN of role for Elasticsearch users"
+  description = "The ARN of the IAM role to allow access to Elasticsearch cluster"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,7 @@ variable "dns_zone_id" {
 
 variable "elasticsearch_version" {
   type        = "string"
-  default     = "6.2"
+  default     = "6.5"
   description = "Version of Elasticsearch to deploy"
 }
 
@@ -86,6 +86,12 @@ variable "iam_role_arns" {
   type        = "list"
   default     = []
   description = "List of IAM role ARNs to permit access to the Elasticsearch domain"
+}
+
+variable "iam_authorizing_role_arns" {
+  type        = "list"
+  default     = []
+  description = "List of IAM role ARNs to permit to assume the Elasticsearch user role"
 }
 
 variable "iam_actions" {


### PR DESCRIPTION
## what
- Create IAM role for access to Elasticsearch
- Update default Elasticsearch version from 6.2 to 6.5
## why
- Limit access among the cluster to the few who need it
- Stay current