### PR TITLE
Use module.label.name for the domain name instead of module.label.id.…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -117,7 +117,7 @@ resource "null_resource" "azs" {
 
 resource "aws_elasticsearch_domain" "default" {
   count                 = var.enabled ? 1 : 0
-  domain_name           = module.label.id
+  domain_name           = module.label.name
   elasticsearch_version = var.elasticsearch_version
 
   advanced_options = var.advanced_options


### PR DESCRIPTION
… Fixes Issue #18.

## what
Fixes a possible bug in the module by using name instead of id

## why
ID is a short field and name is much longer

## references
GitHub issue #18

