### PR TITLE
elasticsearch_subdomain_name variable added

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Available targets:
 | ebs_iops | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | string | `0` | no |
 | ebs_volume_size | Optionally use EBS volumes for data storage by specifying volume size in GB | string | `0` | no |
 | ebs_volume_type | Storage type of EBS volumes | string | `gp2` | no |
+| elasticsearch_subdomain_name | The name of the subdomain for Elasticsearch endpoint in the DNS zone (_e.g._ `elasticsearch`). If empty then module name will be used. | string | `` | no |
 | elasticsearch_version | Version of Elasticsearch to deploy | string | `6.5` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | encrypt_at_rest_enabled | Whether to enable encryption at rest | string | `true` | no |
@@ -352,7 +353,6 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
   [sarkis_homepage]: https://github.com/sarkis
   [sarkis_avatar]: https://img.cloudposse.com/150x150/https://github.com/sarkis.png
-
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -16,6 +16,7 @@
 | ebs_iops | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | string | `0` | no |
 | ebs_volume_size | Optionally use EBS volumes for data storage by specifying volume size in GB | string | `0` | no |
 | ebs_volume_type | Storage type of EBS volumes | string | `gp2` | no |
+| elasticsearch_subdomain_name | The name of the subdomain for Elasticsearch endpoint in the DNS zone (_e.g._ `elasticsearch`). If empty then module name will be used. | string | `` | no |
 | elasticsearch_version | Version of Elasticsearch to deploy | string | `6.5` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
 | encrypt_at_rest_enabled | Whether to enable encryption at rest | string | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -198,7 +198,7 @@ module "domain_hostname" {
   enabled   = "${var.enabled == "true" && length(var.dns_zone_id) > 0 ? "true" : "false"}"
   namespace = "${var.namespace}"
   stage     = "${var.stage}"
-  name      = "${var.name}"
+  name      = "${var.elasticsearch_subdomain_name == "" ? var.name : var.elasticsearch_subdomain_name}"
   ttl       = 60
   zone_id   = "${var.dns_zone_id}"
   records   = ["${aws_elasticsearch_domain.default.*.endpoint}"]

--- a/variables.tf
+++ b/variables.tf
@@ -204,6 +204,12 @@ variable "kibana_subdomain_name" {
   description = "The name of the subdomain for Kibana in the DNS zone (_e.g._ `kibana`, `ui`, `ui-es`, `search-ui`, `kibana.elasticsearch`)"
 }
 
+variable "elasticsearch_subdomain_name" {
+  type        = "string"
+  default     = ""
+  description = "The name of the subdomain for Elasticsearch endpoint in the DNS zone (_e.g._ `elasticsearch`). If empty then module name will be used."
+}
+
 variable "create_iam_service_linked_role" {
   type        = "string"
   default     = "true"


### PR DESCRIPTION
## what
* `elasticsearch_subdomain_name` variable added

## why
* to be able to override default value (var.name) with custom subdomain hostname