### PR TITLE
Fix service role creation and mark name as mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,10 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 
 Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
 
+## Discourse Forums
+
+Participate in our [Discourse Forums][discourse]. Here you'll find answers to commonly asked questions. Most questions will be related to the enormous number of projects we support on our GitHub. Come here to collaborate on answers, find solutions, and get ideas about the products and services we value. It only takes a minute to get started! Just sign in with SSO using your GitHub account.
+
 ## Newsletter
 
 Sign up for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover. 
@@ -370,6 +374,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-elasticsearch&utm_content=testimonial
   [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-elasticsearch&utm_content=office_hours
   [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-elasticsearch&utm_content=newsletter
+  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-elasticsearch&utm_content=discourse
   [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-elasticsearch&utm_content=email
   [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-elasticsearch&utm_content=commercial_support
   [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-elasticsearch&utm_content=we_love_open_source

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -58,3 +58,4 @@
 | kibana_endpoint | Domain-specific endpoint for Kibana without https scheme |
 | kibana_hostname | Kibana hostname |
 | security_group_id | Security Group ID to control access to the Elasticsearch domain |
+

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -35,7 +35,7 @@
 | log_publishing_index_enabled | Specifies whether log publishing option for INDEX_SLOW_LOGS is enabled or not | bool | `false` | no |
 | log_publishing_search_cloudwatch_log_group_arn | ARN of the CloudWatch log group to which log for SEARCH_SLOW_LOGS needs to be published | string | `` | no |
 | log_publishing_search_enabled | Specifies whether log publishing option for SEARCH_SLOW_LOGS is enabled or not | bool | `false` | no |
-| name | Solution name, e.g. 'app' or 'jenkins' | string | `` | yes |
+| name | Solution name, e.g. 'app' or 'jenkins' | string | `` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | string | `` | no |
 | node_to_node_encryption_enabled | Whether to enable node-to-node encryption | bool | `false` | no |
 | security_groups | List of security group IDs to be allowed to connect to the cluster | list(string) | `<list>` | no |
@@ -58,4 +58,3 @@
 | kibana_endpoint | Domain-specific endpoint for Kibana without https scheme |
 | kibana_hostname | Kibana hostname |
 | security_group_id | Security Group ID to control access to the Elasticsearch domain |
-

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -35,7 +35,7 @@
 | log_publishing_index_enabled | Specifies whether log publishing option for INDEX_SLOW_LOGS is enabled or not | bool | `false` | no |
 | log_publishing_search_cloudwatch_log_group_arn | ARN of the CloudWatch log group to which log for SEARCH_SLOW_LOGS needs to be published | string | `` | no |
 | log_publishing_search_enabled | Specifies whether log publishing option for SEARCH_SLOW_LOGS is enabled or not | bool | `false` | no |
-| name | Solution name, e.g. 'app' or 'jenkins' | string | `` | no |
+| name | Solution name, e.g. 'app' or 'jenkins' | string | `` | yes |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | string | `` | no |
 | node_to_node_encryption_enabled | Whether to enable node-to-node encryption | bool | `false` | no |
 | security_groups | List of security group IDs to be allowed to connect to the cluster | list(string) | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -66,13 +66,14 @@ resource "aws_security_group_rule" "egress" {
 }
 
 data "aws_iam_role" "default" {
-  count = var.enabled ? 1 : 0
+  count = var.enabled && var.create_iam_service_linked_role == 0 ? 1 : 0
   name  = "AWSServiceRoleForAmazonElasticsearchService"
+
 }
 
 # https://github.com/terraform-providers/terraform-provider-aws/issues/5218
 resource "aws_iam_service_linked_role" "default" {
-  count            = var.enabled && length(data.aws_iam_role.default.*.id) == 0 ? 1 : 0
+  count            = var.enabled && length(data.aws_iam_role.default.*.id) == 0 && var.create_iam_service_linked_role == 1 ? 1 : 0
   aws_service_name = "es.amazonaws.com"
   description      = "AWSServiceRoleForAmazonElasticsearchService Service-Linked Role"
 }

--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ data "aws_iam_role" "default" {
 
 # https://github.com/terraform-providers/terraform-provider-aws/issues/5218
 resource "aws_iam_service_linked_role" "default" {
-  count            = var.enabled && length(data.aws_iam_role.default.*.id) == 0 && var.create_iam_service_linked_role == 1 ? 1 : 0
+  count            = var.enabled && var.create_iam_service_linked_role && length(data.aws_iam_role.default.*.id) == 0 ? 1 : 0
   aws_service_name = "es.amazonaws.com"
   description      = "AWSServiceRoleForAmazonElasticsearchService Service-Linked Role"
 }


### PR DESCRIPTION
## what
* fix create_iam_service_linked_role logic and support for var.create_iam_service_linked_role
* mark "name" as a required input parameter. 

## why
* fix the issue described in https://github.com/cloudposse/terraform-aws-elasticsearch/issues/44
* in case none of name, namespace, environment, stage inputs specified, this code https://github.com/cloudposse/terraform-null-label/blob/master/main.tf#L57 produces inconsistent name for ElasticSearch cluster. I suggest making the "name" mandatory. 

## references
* closes #44

