### PR TITLE
Fix #14 invalid kibana_hostname

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -235,5 +235,5 @@ module "kibana_hostname" {
   name    = var.kibana_subdomain_name
   ttl     = 60
   zone_id = var.dns_zone_id
-  records = [join("", aws_elasticsearch_domain.default.*.kibana_endpoint)]
+  records = [join("", aws_elasticsearch_domain.default.*.endpoint)]
 }


### PR DESCRIPTION
Fix #14 by setting the kibana_hostname equal to the ES endpoint rather
then then aws_elasticsearch_domain.kibana_endpoint.
aws_elasticsearch_domain.kibana_endpoint is the complete URL to the
endpoint including the path /_plugin/kibana/ which makes for an invalid
CNAME.
