### PR TITLE
Additional functionality to enable Cognito Authentication for Kibana

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ Available targets:
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
 | automated_snapshot_start_hour | Hour at which automated snapshots are taken, in UTC | number | `0` | no |
 | availability_zone_count | Number of Availability Zones for the domain to use. | number | `2` | no |
+| cognito_authentication_enabled | Whether to enable Amazon Cognito authentication with Kibana | bool | `false` | no |
+| cognito_iam_role_arn | ARN of the IAM role that has the AmazonESCognitoAccess policy attached | string | `` | no |
+| cognito_identity_pool_id | The ID of the Cognito Identity Pool to use | string | `` | no |
+| cognito_user_pool_id | The ID of the Cognito User Pool to use | string | `` | no |
 | create_iam_service_linked_role | Whether to create `AWSServiceRoleForAmazonElasticsearchService` service-linked role. Set it to `false` if you already have an ElasticSearch cluster created in the AWS account and AWSServiceRoleForAmazonElasticsearchService already exists. See https://github.com/terraform-providers/terraform-provider-aws/issues/5218 for more info | bool | `true` | no |
 | dedicated_master_count | Number of dedicated master nodes in the cluster | number | `0` | no |
 | dedicated_master_enabled | Indicates whether dedicated master nodes are enabled for the cluster | bool | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,6 +7,10 @@
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
 | automated_snapshot_start_hour | Hour at which automated snapshots are taken, in UTC | number | `0` | no |
 | availability_zone_count | Number of Availability Zones for the domain to use. | number | `2` | no |
+| cognito_authentication_enabled | Whether to enable Amazon Cognito authentication with Kibana | bool | `false` | no |
+| cognito_iam_role_arn | ARN of the IAM role that has the AmazonESCognitoAccess policy attached | string | `` | no |
+| cognito_identity_pool_id | The ID of the Cognito Identity Pool to use | string | `` | no |
+| cognito_user_pool_id | The ID of the Cognito User Pool to use | string | `` | no |
 | create_iam_service_linked_role | Whether to create `AWSServiceRoleForAmazonElasticsearchService` service-linked role. Set it to `false` if you already have an ElasticSearch cluster created in the AWS account and AWSServiceRoleForAmazonElasticsearchService already exists. See https://github.com/terraform-providers/terraform-provider-aws/issues/5218 for more info | bool | `true` | no |
 | dedicated_master_count | Number of dedicated master nodes in the cluster | number | `0` | no |
 | dedicated_master_enabled | Indicates whether dedicated master nodes are enabled for the cluster | bool | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -172,14 +172,14 @@ resource "aws_elasticsearch_domain" "default" {
   snapshot_options {
     automated_snapshot_start_hour = var.automated_snapshot_start_hour
   }
-    
+
   cognito_options {
     enabled          = var.cognito_authentication_enabled
     user_pool_id     = var.cognito_user_pool_id
     identity_pool_id = var.cognito_identity_pool_id
     role_arn         = var.cognito_iam_role_arn
   }
-    
+
   log_publishing_options {
     enabled                  = var.log_publishing_index_enabled
     log_type                 = "INDEX_SLOW_LOGS"

--- a/main.tf
+++ b/main.tf
@@ -172,7 +172,14 @@ resource "aws_elasticsearch_domain" "default" {
   snapshot_options {
     automated_snapshot_start_hour = var.automated_snapshot_start_hour
   }
-
+    
+  cognito_options {
+    enabled          = var.cognito_authentication_enabled
+    user_pool_id     = var.cognito_user_pool_id
+    identity_pool_id = var.cognito_identity_pool_id
+    role_arn         = var.cognito_iam_role_arn
+  }
+    
   log_publishing_options {
     enabled                  = var.log_publishing_index_enabled
     log_type                 = "INDEX_SLOW_LOGS"

--- a/variables.tf
+++ b/variables.tf
@@ -247,3 +247,27 @@ variable "iam_role_max_session_duration" {
   default     = 3600
   description = "The maximum session duration (in seconds) for the user role. Can have a value from 1 hour to 12 hours"
 }
+
+variable "cognito_authentication_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether to enable Amazon Cognito authentication with Kibana"
+}
+
+variable "cognito_user_pool_id" {
+  type        = string
+  default     = ""
+  description = "The ID of the Cognito User Pool to use"
+}
+
+variable "cognito_identity_pool_id" {
+  type        = string
+  default     = ""
+  description = "The ID of the Cognito Identity Pool to use"
+}
+
+variable "cognito_iam_role_arn" {
+  type        = string
+  default     = ""
+  description = "ARN of the IAM role that has the AmazonESCognitoAccess policy attached"
+}


### PR DESCRIPTION
## what
* Allow the user to enable Cognito Authentication for Kibana

## why
* The module does not allow for this functionality although the TF provider does
* Fixes issue #26

## references
* https://www.terraform.io/docs/providers/aws/r/elasticsearch_domain.html
* https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-cognito-auth.html


