### PR TITLE
Add domain_name to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Available targets:
 | domain_endpoint | Domain-specific endpoint used to submit index, search, and data upload requests |
 | domain_hostname | Elasticsearch domain hostname to submit index, search, and data upload requests |
 | domain_id | Unique identifier for the Elasticsearch domain |
+| domain_name | Name of the Elasticsearch domain |
 | elasticsearch_user_iam_role_arn | The ARN of the IAM role to allow access to Elasticsearch cluster |
 | elasticsearch_user_iam_role_name | The name of the IAM role to allow access to Elasticsearch cluster |
 | kibana_endpoint | Domain-specific endpoint for Kibana without https scheme |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -57,6 +57,7 @@
 | domain_endpoint | Domain-specific endpoint used to submit index, search, and data upload requests |
 | domain_hostname | Elasticsearch domain hostname to submit index, search, and data upload requests |
 | domain_id | Unique identifier for the Elasticsearch domain |
+| domain_name | Name of the Elasticsearch domain |
 | elasticsearch_user_iam_role_arn | The ARN of the IAM role to allow access to Elasticsearch cluster |
 | elasticsearch_user_iam_role_name | The name of the IAM role to allow access to Elasticsearch cluster |
 | kibana_endpoint | Domain-specific endpoint for Kibana without https scheme |

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "domain_id" {
   description = "Unique identifier for the Elasticsearch domain"
 }
 
+output "domain_name" {
+  value       = join("", aws_elasticsearch_domain.default.*.domain_name)
+  description = "Name of the Elasticsearch domain"
+}
+
 output "domain_endpoint" {
   value       = join("", aws_elasticsearch_domain.default.*.endpoint)
   description = "Domain-specific endpoint used to submit index, search, and data upload requests"


### PR DESCRIPTION
## what
Add `domain_name` to outputs.

## why
* We are configuring monitoring alerts in Elasticsearch that require the `domain_name`.