### PR TITLE
Fix `count` for resources

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -64,3 +64,4 @@
 | kibana_endpoint | Domain-specific endpoint for Kibana without https scheme |
 | kibana_hostname | Kibana hostname |
 | security_group_id | Security Group ID to control access to the Elasticsearch domain |
+

--- a/main.tf
+++ b/main.tf
@@ -65,15 +65,9 @@ resource "aws_security_group_rule" "egress" {
   security_group_id = join("", aws_security_group.default.*.id)
 }
 
-data "aws_iam_role" "default" {
-  count = var.enabled && var.create_iam_service_linked_role == 0 ? 1 : 0
-  name  = "AWSServiceRoleForAmazonElasticsearchService"
-
-}
-
 # https://github.com/terraform-providers/terraform-provider-aws/issues/5218
 resource "aws_iam_service_linked_role" "default" {
-  count            = var.enabled && var.create_iam_service_linked_role && length(data.aws_iam_role.default.*.id) == 0 ? 1 : 0
+  count            = var.enabled && var.create_iam_service_linked_role ? 1 : 0
   aws_service_name = "es.amazonaws.com"
   description      = "AWSServiceRoleForAmazonElasticsearchService Service-Linked Role"
 }
@@ -115,7 +109,7 @@ data "aws_iam_policy_document" "assume_role" {
 # I use 0.12 new "dynamic" block - https://www.terraform.io/docs/configuration/expressions.html
 # If we have 1 az - the count of this resource equals 0, hence no config
 # block appears in the `aws_elasticsearch_domain`
-# If we have more than 1 - we set the trigger to the actual value of 
+# If we have more than 1 - we set the trigger to the actual value of
 # `availability_zone_count`
 # and `dynamic` block kicks in
 resource "null_resource" "azs" {


### PR DESCRIPTION
## what
* Fix `count` for resources
* Don't use data sources in counts

## why
* When an output from a data source is used in `counts`, in some cases Terraform can't compute the counts throwing the errors (it's working in the Terratest, but does not work for some customers):

```
Error: Invalid count argument
 on .terraform/modules/search_service_elasticsearch_master.elasticsearch/main.tf line 76, in resource "aws_iam_service_linked_role" "default":
 76:   count            = var.enabled && var.create_iam_service_linked_role && length(data.aws_iam_role.default.*.id) == 0 ? 1 : 0
The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```

* We have a bool variable `create_iam_service_linked_role` to control that without using data sources. If the AWS account (where the module is provisioned) already has the `AWSServiceRoleForAmazonElasticsearchService` service role, set the variable `create_iam_service_linked_role` to `false`. On a new account, set it to `true`


