### PR TITLE
Allow configuration of ingress port range

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Available targets:
 | iam_authorizing_role_arns | List of IAM role ARNs to permit to assume the Elasticsearch user role | list(string) | `<list>` | no |
 | iam_role_arns | List of IAM role ARNs to permit access to the Elasticsearch domain | list(string) | `<list>` | no |
 | iam_role_max_session_duration | The maximum session duration (in seconds) for the user role. Can have a value from 1 hour to 12 hours | number | `3600` | no |
+| ingress_port_range_end | End number for allowed port range. (e.g. `443`) | number | `65535` | no |
+| ingress_port_range_start | Start number for allowed port range. (e.g. `443`) | number | `0` | no |
 | instance_count | Number of data nodes in the cluster | number | `4` | no |
 | instance_type | Elasticsearch instance type for data nodes in the cluster | string | `t2.small.elasticsearch` | no |
 | kibana_subdomain_name | The name of the subdomain for Kibana in the DNS zone (_e.g._ `kibana`, `ui`, `ui-es`, `search-ui`, `kibana.elasticsearch`) | string | `kibana` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -30,6 +30,8 @@
 | iam_authorizing_role_arns | List of IAM role ARNs to permit to assume the Elasticsearch user role | list(string) | `<list>` | no |
 | iam_role_arns | List of IAM role ARNs to permit access to the Elasticsearch domain | list(string) | `<list>` | no |
 | iam_role_max_session_duration | The maximum session duration (in seconds) for the user role. Can have a value from 1 hour to 12 hours | number | `3600` | no |
+| ingress_port_range_end | End number for allowed port range. (e.g. `443`) | number | `65535` | no |
+| ingress_port_range_start | Start number for allowed port range. (e.g. `443`) | number | `0` | no |
 | instance_count | Number of data nodes in the cluster | number | `4` | no |
 | instance_type | Elasticsearch instance type for data nodes in the cluster | string | `t2.small.elasticsearch` | no |
 | kibana_subdomain_name | The name of the subdomain for Kibana in the DNS zone (_e.g._ `kibana`, `ui`, `ui-es`, `search-ui`, `kibana.elasticsearch`) | string | `kibana` | no |

--- a/main.tf
+++ b/main.tf
@@ -36,8 +36,8 @@ resource "aws_security_group_rule" "ingress_security_groups" {
   count                    = var.enabled ? length(var.security_groups) : 0
   description              = "Allow inbound traffic from Security Groups"
   type                     = "ingress"
-  from_port                = 0
-  to_port                  = 65535
+  from_port                = var.ingress_port_range_start
+  to_port                  = var.ingress_port_range_end
   protocol                 = "tcp"
   source_security_group_id = var.security_groups[count.index]
   security_group_id        = join("", aws_security_group.default.*.id)
@@ -47,8 +47,8 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
   count             = var.enabled && length(var.allowed_cidr_blocks) > 0 ? 1 : 0
   description       = "Allow inbound traffic from CIDR blocks"
   type              = "ingress"
-  from_port         = 0
-  to_port           = 65535
+  from_port         = var.ingress_port_range_start
+  to_port           = var.ingress_port_range_end
   protocol          = "tcp"
   cidr_blocks       = var.allowed_cidr_blocks
   security_group_id = join("", aws_security_group.default.*.id)

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,18 @@ variable "security_groups" {
   description = "List of security group IDs to be allowed to connect to the cluster"
 }
 
+variable "ingress_port_range_start" {
+  type        = number
+  default     = 0
+  description = "Start number for allowed port range. (e.g. `443`)"
+}
+
+variable "ingress_port_range_end" {
+  type        = number
+  default     = 65535
+  description = "End number for allowed port range. (e.g. `443`)"
+}
+
 variable "allowed_cidr_blocks" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
## what
- Adds configuration variables to modify the range of allowed ingress ports (or port)

## why
- Allow to limit communication to only port 443 to enforce SSL usage in ES connectivity

## references