### PR TITLE
Add domain_endpoint_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Available targets:
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
 | dns_zone_id | Route53 DNS Zone ID to add hostname records for Elasticsearch domain and Kibana | string | `` | no |
 | domain_endpoint_options_enforce_https | Whether or not to require HTTPS | bool | `false` | no |
+| domain_endpoint_options_tls_security_policy | The name of the TLS security policy that needs to be applied to the HTTPS endpoint | string | `Policy-Min-TLS-1-0-2019-07` | no |
 | ebs_iops | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | number | `0` | no |
 | ebs_volume_size | EBS volumes for data storage in GB | number | `0` | no |
 | ebs_volume_type | Storage type of EBS volumes | string | `gp2` | no |

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Available targets:
 | dedicated_master_type | Instance type of the dedicated master nodes in the cluster | string | `t2.small.elasticsearch` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
 | dns_zone_id | Route53 DNS Zone ID to add hostname records for Elasticsearch domain and Kibana | string | `` | no |
+| domain_endpoint_options_enforce_https | Whether or not to require HTTPS | bool | `false` | no |
 | ebs_iops | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | number | `0` | no |
 | ebs_volume_size | EBS volumes for data storage in GB | number | `0` | no |
 | ebs_volume_type | Storage type of EBS volumes | string | `gp2` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -17,6 +17,7 @@
 | dedicated_master_type | Instance type of the dedicated master nodes in the cluster | string | `t2.small.elasticsearch` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
 | dns_zone_id | Route53 DNS Zone ID to add hostname records for Elasticsearch domain and Kibana | string | `` | no |
+| domain_endpoint_options_enforce_https | Whether or not to require HTTPS | bool | `false` | no |
 | ebs_iops | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | number | `0` | no |
 | ebs_volume_size | EBS volumes for data storage in GB | number | `0` | no |
 | ebs_volume_type | Storage type of EBS volumes | string | `gp2` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,6 +18,7 @@
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
 | dns_zone_id | Route53 DNS Zone ID to add hostname records for Elasticsearch domain and Kibana | string | `` | no |
 | domain_endpoint_options_enforce_https | Whether or not to require HTTPS | bool | `false` | no |
+| domain_endpoint_options_tls_security_policy | The name of the TLS security policy that needs to be applied to the HTTPS endpoint | string | `Policy-Min-TLS-1-0-2019-07` | no |
 | ebs_iops | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | number | `0` | no |
 | ebs_volume_size | EBS volumes for data storage in GB | number | `0` | no |
 | ebs_volume_type | Storage type of EBS volumes | string | `gp2` | no |

--- a/main.tf
+++ b/main.tf
@@ -138,6 +138,10 @@ resource "aws_elasticsearch_domain" "default" {
     kms_key_id = var.encrypt_at_rest_kms_key_id
   }
 
+  domain_endpoint_options {
+    enforce_https = var.domain_endpoint_options_enforce_https
+  }
+
   cluster_config {
     instance_count           = var.instance_count
     instance_type            = var.instance_type

--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,8 @@ resource "aws_elasticsearch_domain" "default" {
   }
 
   domain_endpoint_options {
-    enforce_https = var.domain_endpoint_options_enforce_https
+    enforce_https       = var.domain_endpoint_options_enforce_https
+    tls_security_policy = var.domain_endpoint_options_tls_security_policy
   }
 
   cluster_config {

--- a/variables.tf
+++ b/variables.tf
@@ -170,6 +170,12 @@ variable "encrypt_at_rest_kms_key_id" {
   description = "The KMS key ID to encrypt the Elasticsearch domain with. If not specified, then it defaults to using the AWS/Elasticsearch service KMS key"
 }
 
+variable "domain_endpoint_options_enforce_https" {
+  type        = bool
+  default     = false
+  description = "Whether or not to require HTTPS"
+}
+
 variable "log_publishing_index_enabled" {
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -176,6 +176,13 @@ variable "domain_endpoint_options_enforce_https" {
   description = "Whether or not to require HTTPS"
 }
 
+variable "domain_endpoint_options_tls_security_policy" {
+  type        = string
+  default     = "Policy-Min-TLS-1-0-2019-07"
+  description = "The name of the TLS security policy that needs to be applied to the HTTPS endpoint"
+}
+
+
 variable "log_publishing_index_enabled" {
   type        = bool
   default     = false


### PR DESCRIPTION
## what
Add `domain_endpoint_options` variable.

## why
To be able to configure enforce https in `elasticsearch_domain` resource.

## references
https://www.terraform.io/docs/providers/aws/r/elasticsearch_domain.html#enforce_https

