### PR TITLE
Ability to spin ES cluster outside of VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Available targets:
 | dedicated\_master\_type | Instance type of the dedicated master nodes in the cluster | `string` | `"t2.small.elasticsearch"` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
 | dns\_zone\_id | Route53 DNS Zone ID to add hostname records for Elasticsearch domain and Kibana | `string` | `""` | no |
+| domain\_endpoint\_options\_enforce\_https | Whether or not to require HTTPS | `bool` | `false` | no |
+| domain\_endpoint\_options\_tls\_security\_policy | The name of the TLS security policy that needs to be applied to the HTTPS endpoint | `string` | `"Policy-Min-TLS-1-0-2019-07"` | no |
 | ebs\_iops | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | `number` | `0` | no |
 | ebs\_volume\_size | EBS volumes for data storage in GB | `number` | `0` | no |
 | ebs\_volume\_type | Storage type of EBS volumes | `string` | `"gp2"` | no |
@@ -267,7 +269,7 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 
 - **Reference Architecture.** You'll get everything you need from the ground up built using 100% infrastructure as code.
 - **Release Engineering.** You'll have end-to-end CI/CD with unlimited staging environments.
-- **Site Reliability Engineering.** You'll have total visibility into your apps and microservices.
+t - **Site Reliability Engineering.** You'll have total visibility into your apps and microservices.
 - **Security Baseline.** You'll have built-in governance with accountability and audit logs for all changes.
 - **GitOps.** You'll be able to operate your infrastructure via Pull Requests.
 - **Training.** You'll receive hands-on training so your team can operate what we build.

--- a/README.md
+++ b/README.md
@@ -141,77 +141,91 @@ Available targets:
   lint                                Lint terraform code
 
 ```
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+| null | ~> 2.0 |
+| template | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+| null | ~> 2.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| advanced_options | Key-value string pairs to specify advanced configuration options | map(string) | `<map>` | no |
-| allowed_cidr_blocks | List of CIDR blocks to be allowed to connect to the cluster | list(string) | `<list>` | no |
-| attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
-| automated_snapshot_start_hour | Hour at which automated snapshots are taken, in UTC | number | `0` | no |
-| availability_zone_count | Number of Availability Zones for the domain to use. | number | `2` | no |
-| cognito_authentication_enabled | Whether to enable Amazon Cognito authentication with Kibana | bool | `false` | no |
-| cognito_iam_role_arn | ARN of the IAM role that has the AmazonESCognitoAccess policy attached | string | `` | no |
-| cognito_identity_pool_id | The ID of the Cognito Identity Pool to use | string | `` | no |
-| cognito_user_pool_id | The ID of the Cognito User Pool to use | string | `` | no |
-| create_iam_service_linked_role | Whether to create `AWSServiceRoleForAmazonElasticsearchService` service-linked role. Set it to `false` if you already have an ElasticSearch cluster created in the AWS account and AWSServiceRoleForAmazonElasticsearchService already exists. See https://github.com/terraform-providers/terraform-provider-aws/issues/5218 for more info | bool | `true` | no |
-| dedicated_master_count | Number of dedicated master nodes in the cluster | number | `0` | no |
-| dedicated_master_enabled | Indicates whether dedicated master nodes are enabled for the cluster | bool | `false` | no |
-| dedicated_master_type | Instance type of the dedicated master nodes in the cluster | string | `t2.small.elasticsearch` | no |
-| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
-| dns_zone_id | Route53 DNS Zone ID to add hostname records for Elasticsearch domain and Kibana | string | `` | no |
-| domain_endpoint_options_enforce_https | Whether or not to require HTTPS | bool | `false` | no |
-| domain_endpoint_options_tls_security_policy | The name of the TLS security policy that needs to be applied to the HTTPS endpoint | string | `Policy-Min-TLS-1-0-2019-07` | no |
-| ebs_iops | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | number | `0` | no |
-| ebs_volume_size | EBS volumes for data storage in GB | number | `0` | no |
-| ebs_volume_type | Storage type of EBS volumes | string | `gp2` | no |
-| elasticsearch_subdomain_name | The name of the subdomain for Elasticsearch in the DNS zone (_e.g._ `elasticsearch`, `ui`, `ui-es`, `search-ui`) | string | `` | no |
-| elasticsearch_version | Version of Elasticsearch to deploy (_e.g._ `7.1`, `6.8`, `6.7`, `6.5`, `6.4`, `6.3`, `6.2`, `6.0`, `5.6`, `5.5`, `5.3`, `5.1`, `2.3`, `1.5` | string | `6.8` | no |
-| enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
-| encrypt_at_rest_enabled | Whether to enable encryption at rest | bool | `true` | no |
-| encrypt_at_rest_kms_key_id | The KMS key ID to encrypt the Elasticsearch domain with. If not specified, then it defaults to using the AWS/Elasticsearch service KMS key | string | `` | no |
-| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |
-| iam_actions | List of actions to allow for the IAM roles, _e.g._ `es:ESHttpGet`, `es:ESHttpPut`, `es:ESHttpPost` | list(string) | `<list>` | no |
-| iam_authorizing_role_arns | List of IAM role ARNs to permit to assume the Elasticsearch user role | list(string) | `<list>` | no |
-| iam_role_arns | List of IAM role ARNs to permit access to the Elasticsearch domain | list(string) | `<list>` | no |
-| iam_role_max_session_duration | The maximum session duration (in seconds) for the user role. Can have a value from 1 hour to 12 hours | number | `3600` | no |
-| ingress_port_range_end | End number for allowed port range. (e.g. `443`) | number | `65535` | no |
-| ingress_port_range_start | Start number for allowed port range. (e.g. `443`) | number | `0` | no |
-| instance_count | Number of data nodes in the cluster | number | `4` | no |
-| instance_type | Elasticsearch instance type for data nodes in the cluster | string | `t2.small.elasticsearch` | no |
-| kibana_subdomain_name | The name of the subdomain for Kibana in the DNS zone (_e.g._ `kibana`, `ui`, `ui-es`, `search-ui`, `kibana.elasticsearch`) | string | `kibana` | no |
-| label_order | The naming order of the id output and Name tag | list(string) | `<list>` | no |
-| log_publishing_application_cloudwatch_log_group_arn | ARN of the CloudWatch log group to which log for ES_APPLICATION_LOGS needs to be published | string | `` | no |
-| log_publishing_application_enabled | Specifies whether log publishing option for ES_APPLICATION_LOGS is enabled or not | bool | `false` | no |
-| log_publishing_index_cloudwatch_log_group_arn | ARN of the CloudWatch log group to which log for INDEX_SLOW_LOGS needs to be published | string | `` | no |
-| log_publishing_index_enabled | Specifies whether log publishing option for INDEX_SLOW_LOGS is enabled or not | bool | `false` | no |
-| log_publishing_search_cloudwatch_log_group_arn | ARN of the CloudWatch log group to which log for SEARCH_SLOW_LOGS needs to be published | string | `` | no |
-| log_publishing_search_enabled | Specifies whether log publishing option for SEARCH_SLOW_LOGS is enabled or not | bool | `false` | no |
-| name | Solution name, e.g. 'app' or 'jenkins' | string | `` | no |
-| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | string | `` | no |
-| node_to_node_encryption_enabled | Whether to enable node-to-node encryption | bool | `false` | no |
-| security_groups | List of security group IDs to be allowed to connect to the cluster | list(string) | `<list>` | no |
-| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |
-| subnet_ids | VPC Subnet IDs | list(string) | `<list>` | no |
-| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | map(string) | `<map>` | no |
-| vpc_enabled | Set to false if ES should be deployed outside of VPC. | bool | `true` | no |
-| vpc_id | VPC ID | string | `null` | no |
-| zone_awareness_enabled | Enable zone awareness for Elasticsearch cluster | bool | `true` | no |
+|------|-------------|------|---------|:--------:|
+| advanced\_options | Key-value string pairs to specify advanced configuration options | `map(string)` | `{}` | no |
+| allowed\_cidr\_blocks | List of CIDR blocks to be allowed to connect to the cluster | `list(string)` | `[]` | no |
+| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| automated\_snapshot\_start\_hour | Hour at which automated snapshots are taken, in UTC | `number` | `0` | no |
+| availability\_zone\_count | Number of Availability Zones for the domain to use. | `number` | `2` | no |
+| cognito\_authentication\_enabled | Whether to enable Amazon Cognito authentication with Kibana | `bool` | `false` | no |
+| cognito\_iam\_role\_arn | ARN of the IAM role that has the AmazonESCognitoAccess policy attached | `string` | `""` | no |
+| cognito\_identity\_pool\_id | The ID of the Cognito Identity Pool to use | `string` | `""` | no |
+| cognito\_user\_pool\_id | The ID of the Cognito User Pool to use | `string` | `""` | no |
+| create\_iam\_service\_linked\_role | Whether to create `AWSServiceRoleForAmazonElasticsearchService` service-linked role. Set it to `false` if you already have an ElasticSearch cluster created in the AWS account and AWSServiceRoleForAmazonElasticsearchService already exists. See https://github.com/terraform-providers/terraform-provider-aws/issues/5218 for more info | `bool` | `true` | no |
+| dedicated\_master\_count | Number of dedicated master nodes in the cluster | `number` | `0` | no |
+| dedicated\_master\_enabled | Indicates whether dedicated master nodes are enabled for the cluster | `bool` | `false` | no |
+| dedicated\_master\_type | Instance type of the dedicated master nodes in the cluster | `string` | `"t2.small.elasticsearch"` | no |
+| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
+| dns\_zone\_id | Route53 DNS Zone ID to add hostname records for Elasticsearch domain and Kibana | `string` | `""` | no |
+| ebs\_iops | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | `number` | `0` | no |
+| ebs\_volume\_size | EBS volumes for data storage in GB | `number` | `0` | no |
+| ebs\_volume\_type | Storage type of EBS volumes | `string` | `"gp2"` | no |
+| elasticsearch\_subdomain\_name | The name of the subdomain for Elasticsearch in the DNS zone (\_e.g.\_ `elasticsearch`, `ui`, `ui-es`, `search-ui`) | `string` | `""` | no |
+| elasticsearch\_version | Version of Elasticsearch to deploy (\_e.g.\_ `7.4`, `7.1`, `6.8`, `6.7`, `6.5`, `6.4`, `6.3`, `6.2`, `6.0`, `5.6`, `5.5`, `5.3`, `5.1`, `2.3`, `1.5` | `string` | `"7.4"` | no |
+| enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
+| encrypt\_at\_rest\_enabled | Whether to enable encryption at rest | `bool` | `true` | no |
+| encrypt\_at\_rest\_kms\_key\_id | The KMS key ID to encrypt the Elasticsearch domain with. If not specified, then it defaults to using the AWS/Elasticsearch service KMS key | `string` | `""` | no |
+| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
+| iam\_actions | List of actions to allow for the IAM roles, _e.g._ `es:ESHttpGet`, `es:ESHttpPut`, `es:ESHttpPost` | `list(string)` | `[]` | no |
+| iam\_authorizing\_role\_arns | List of IAM role ARNs to permit to assume the Elasticsearch user role | `list(string)` | `[]` | no |
+| iam\_role\_arns | List of IAM role ARNs to permit access to the Elasticsearch domain | `list(string)` | `[]` | no |
+| iam\_role\_max\_session\_duration | The maximum session duration (in seconds) for the user role. Can have a value from 1 hour to 12 hours | `number` | `3600` | no |
+| ingress\_port\_range\_end | End number for allowed port range. (e.g. `443`) | `number` | `65535` | no |
+| ingress\_port\_range\_start | Start number for allowed port range. (e.g. `443`) | `number` | `0` | no |
+| instance\_count | Number of data nodes in the cluster | `number` | `4` | no |
+| instance\_type | Elasticsearch instance type for data nodes in the cluster | `string` | `"t2.small.elasticsearch"` | no |
+| kibana\_subdomain\_name | The name of the subdomain for Kibana in the DNS zone (\_e.g.\_ `kibana`, `ui`, `ui-es`, `search-ui`, `kibana.elasticsearch`) | `string` | `"kibana"` | no |
+| label\_order | The naming order of the id output and Name tag | `list(string)` | `[]` | no |
+| log\_publishing\_application\_cloudwatch\_log\_group\_arn | ARN of the CloudWatch log group to which log for ES\_APPLICATION\_LOGS needs to be published | `string` | `""` | no |
+| log\_publishing\_application\_enabled | Specifies whether log publishing option for ES\_APPLICATION\_LOGS is enabled or not | `bool` | `false` | no |
+| log\_publishing\_index\_cloudwatch\_log\_group\_arn | ARN of the CloudWatch log group to which log for INDEX\_SLOW\_LOGS needs to be published | `string` | `""` | no |
+| log\_publishing\_index\_enabled | Specifies whether log publishing option for INDEX\_SLOW\_LOGS is enabled or not | `bool` | `false` | no |
+| log\_publishing\_search\_cloudwatch\_log\_group\_arn | ARN of the CloudWatch log group to which log for SEARCH\_SLOW\_LOGS needs to be published | `string` | `""` | no |
+| log\_publishing\_search\_enabled | Specifies whether log publishing option for SEARCH\_SLOW\_LOGS is enabled or not | `bool` | `false` | no |
+| name | Solution name, e.g. 'app' or 'jenkins' | `string` | `""` | no |
+| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
+| node\_to\_node\_encryption\_enabled | Whether to enable node-to-node encryption | `bool` | `false` | no |
+| security\_groups | List of security group IDs to be allowed to connect to the cluster | `list(string)` | `[]` | no |
+| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `""` | no |
+| subnet\_ids | VPC Subnet IDs | `list(string)` | `[]` | no |
+| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| vpc\_enabled | Set to false if ES should be deployed outside of VPC. | `bool` | `true` | no |
+| vpc\_id | VPC ID | `string` | `null` | no |
+| zone\_awareness\_enabled | Enable zone awareness for Elasticsearch cluster | `bool` | `true` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| domain_arn | ARN of the Elasticsearch domain |
-| domain_endpoint | Domain-specific endpoint used to submit index, search, and data upload requests |
-| domain_hostname | Elasticsearch domain hostname to submit index, search, and data upload requests |
-| domain_id | Unique identifier for the Elasticsearch domain |
-| domain_name | Name of the Elasticsearch domain |
-| elasticsearch_user_iam_role_arn | The ARN of the IAM role to allow access to Elasticsearch cluster |
-| elasticsearch_user_iam_role_name | The name of the IAM role to allow access to Elasticsearch cluster |
-| kibana_endpoint | Domain-specific endpoint for Kibana without https scheme |
-| kibana_hostname | Kibana hostname |
-| security_group_id | Security Group ID to control access to the Elasticsearch domain |
+| domain\_arn | ARN of the Elasticsearch domain |
+| domain\_endpoint | Domain-specific endpoint used to submit index, search, and data upload requests |
+| domain\_hostname | Elasticsearch domain hostname to submit index, search, and data upload requests |
+| domain\_id | Unique identifier for the Elasticsearch domain |
+| domain\_name | Name of the Elasticsearch domain |
+| elasticsearch\_user\_iam\_role\_arn | The ARN of the IAM role to allow access to Elasticsearch cluster |
+| elasticsearch\_user\_iam\_role\_name | The name of the IAM role to allow access to Elasticsearch cluster |
+| kibana\_endpoint | Domain-specific endpoint for Kibana without https scheme |
+| kibana\_hostname | Kibana hostname |
+| security\_group\_id | Security Group ID to control access to the Elasticsearch domain |
 
 
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 
 - **Reference Architecture.** You'll get everything you need from the ground up built using 100% infrastructure as code.
 - **Release Engineering.** You'll have end-to-end CI/CD with unlimited staging environments.
-t - **Site Reliability Engineering.** You'll have total visibility into your apps and microservices.
+- **Site Reliability Engineering.** You'll have total visibility into your apps and microservices.
 - **Security Baseline.** You'll have built-in governance with accountability and audit logs for all changes.
 - **GitOps.** You'll be able to operate your infrastructure via Pull Requests.
 - **Training.** You'll receive hands-on training so your team can operate what we build.

--- a/README.md
+++ b/README.md
@@ -192,9 +192,10 @@ Available targets:
 | node_to_node_encryption_enabled | Whether to enable node-to-node encryption | bool | `false` | no |
 | security_groups | List of security group IDs to be allowed to connect to the cluster | list(string) | `<list>` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |
-| subnet_ids | Subnet IDs | list(string) | `<list>` | no |
+| subnet_ids | VPC Subnet IDs | list(string) | `<list>` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | map(string) | `<map>` | no |
-| vpc_id | VPC ID | string | `` | no |
+| vpc_enabled | Set to false if ES should be deployed outside of VPC. | bool | `true` | no |
+| vpc_id | VPC ID | string | `null` | no |
 | zone_awareness_enabled | Enable zone awareness for Elasticsearch cluster | bool | `true` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ Available targets:
 | node_to_node_encryption_enabled | Whether to enable node-to-node encryption | bool | `false` | no |
 | security_groups | List of security group IDs to be allowed to connect to the cluster | list(string) | `<list>` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |
-| subnet_ids | Subnet IDs | list(string) | - | yes |
+| subnet_ids | Subnet IDs | list(string) | `<list>` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | map(string) | `<map>` | no |
-| vpc_id | VPC ID | string | - | yes |
+| vpc_id | VPC ID | string | `` | no |
 | zone_awareness_enabled | Enable zone awareness for Elasticsearch cluster | bool | `true` | no |
 
 ## Outputs
@@ -357,8 +357,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Sarkis Varozian][sarkis_avatar]][sarkis_homepage]<br/>[Sarkis Varozian][sarkis_homepage] |
-|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Sarkis Varozian][sarkis_avatar]][sarkis_homepage]<br/>[Sarkis Varozian][sarkis_homepage] | [![Marcin Brański][3h4x_avatar]][3h4x_homepage]<br/>[Marcin Brański][3h4x_homepage] |
+|---|---|---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
@@ -368,6 +368,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
   [sarkis_homepage]: https://github.com/sarkis
   [sarkis_avatar]: https://img.cloudposse.com/150x150/https://github.com/sarkis.png
+  [3h4x_homepage]: https://github.com/3h4x
+  [3h4x_avatar]: https://img.cloudposse.com/150x150/https://github.com/3h4x.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -117,3 +117,5 @@ contributors:
     github: "goruha"
   - name: "Sarkis Varozian"
     github: "sarkis"
+  - name: "Marcin Brański"
+    github: "3h4x"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -49,9 +49,10 @@
 | node_to_node_encryption_enabled | Whether to enable node-to-node encryption | bool | `false` | no |
 | security_groups | List of security group IDs to be allowed to connect to the cluster | list(string) | `<list>` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |
-| subnet_ids | Subnet IDs | list(string) | `<list>` | no |
+| subnet_ids | VPC Subnet IDs | list(string) | `<list>` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | map(string) | `<map>` | no |
-| vpc_id | VPC ID | string | `` | no |
+| vpc_enabled | Set to false if ES should be deployed outside of VPC. | bool | `true` | no |
+| vpc_id | VPC ID | string | `null` | no |
 | zone_awareness_enabled | Enable zone awareness for Elasticsearch cluster | bool | `true` | no |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -33,6 +33,8 @@
 | dedicated\_master\_type | Instance type of the dedicated master nodes in the cluster | `string` | `"t2.small.elasticsearch"` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
 | dns\_zone\_id | Route53 DNS Zone ID to add hostname records for Elasticsearch domain and Kibana | `string` | `""` | no |
+| domain\_endpoint\_options\_enforce\_https | Whether or not to require HTTPS | `bool` | `false` | no |
+| domain\_endpoint\_options\_tls\_security\_policy | The name of the TLS security policy that needs to be applied to the HTTPS endpoint | `string` | `"Policy-Min-TLS-1-0-2019-07"` | no |
 | ebs\_iops | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | `number` | `0` | no |
 | ebs\_volume\_size | EBS volumes for data storage in GB | `number` | `0` | no |
 | ebs\_volume\_type | Storage type of EBS volumes | `string` | `"gp2"` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,72 +1,86 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+| null | ~> 2.0 |
+| template | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+| null | ~> 2.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| advanced_options | Key-value string pairs to specify advanced configuration options | map(string) | `<map>` | no |
-| allowed_cidr_blocks | List of CIDR blocks to be allowed to connect to the cluster | list(string) | `<list>` | no |
-| attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
-| automated_snapshot_start_hour | Hour at which automated snapshots are taken, in UTC | number | `0` | no |
-| availability_zone_count | Number of Availability Zones for the domain to use. | number | `2` | no |
-| cognito_authentication_enabled | Whether to enable Amazon Cognito authentication with Kibana | bool | `false` | no |
-| cognito_iam_role_arn | ARN of the IAM role that has the AmazonESCognitoAccess policy attached | string | `` | no |
-| cognito_identity_pool_id | The ID of the Cognito Identity Pool to use | string | `` | no |
-| cognito_user_pool_id | The ID of the Cognito User Pool to use | string | `` | no |
-| create_iam_service_linked_role | Whether to create `AWSServiceRoleForAmazonElasticsearchService` service-linked role. Set it to `false` if you already have an ElasticSearch cluster created in the AWS account and AWSServiceRoleForAmazonElasticsearchService already exists. See https://github.com/terraform-providers/terraform-provider-aws/issues/5218 for more info | bool | `true` | no |
-| dedicated_master_count | Number of dedicated master nodes in the cluster | number | `0` | no |
-| dedicated_master_enabled | Indicates whether dedicated master nodes are enabled for the cluster | bool | `false` | no |
-| dedicated_master_type | Instance type of the dedicated master nodes in the cluster | string | `t2.small.elasticsearch` | no |
-| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
-| dns_zone_id | Route53 DNS Zone ID to add hostname records for Elasticsearch domain and Kibana | string | `` | no |
-| domain_endpoint_options_enforce_https | Whether or not to require HTTPS | bool | `false` | no |
-| domain_endpoint_options_tls_security_policy | The name of the TLS security policy that needs to be applied to the HTTPS endpoint | string | `Policy-Min-TLS-1-0-2019-07` | no |
-| ebs_iops | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | number | `0` | no |
-| ebs_volume_size | EBS volumes for data storage in GB | number | `0` | no |
-| ebs_volume_type | Storage type of EBS volumes | string | `gp2` | no |
-| elasticsearch_subdomain_name | The name of the subdomain for Elasticsearch in the DNS zone (_e.g._ `elasticsearch`, `ui`, `ui-es`, `search-ui`) | string | `` | no |
-| elasticsearch_version | Version of Elasticsearch to deploy (_e.g._ `7.1`, `6.8`, `6.7`, `6.5`, `6.4`, `6.3`, `6.2`, `6.0`, `5.6`, `5.5`, `5.3`, `5.1`, `2.3`, `1.5` | string | `6.8` | no |
-| enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
-| encrypt_at_rest_enabled | Whether to enable encryption at rest | bool | `true` | no |
-| encrypt_at_rest_kms_key_id | The KMS key ID to encrypt the Elasticsearch domain with. If not specified, then it defaults to using the AWS/Elasticsearch service KMS key | string | `` | no |
-| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |
-| iam_actions | List of actions to allow for the IAM roles, _e.g._ `es:ESHttpGet`, `es:ESHttpPut`, `es:ESHttpPost` | list(string) | `<list>` | no |
-| iam_authorizing_role_arns | List of IAM role ARNs to permit to assume the Elasticsearch user role | list(string) | `<list>` | no |
-| iam_role_arns | List of IAM role ARNs to permit access to the Elasticsearch domain | list(string) | `<list>` | no |
-| iam_role_max_session_duration | The maximum session duration (in seconds) for the user role. Can have a value from 1 hour to 12 hours | number | `3600` | no |
-| ingress_port_range_end | End number for allowed port range. (e.g. `443`) | number | `65535` | no |
-| ingress_port_range_start | Start number for allowed port range. (e.g. `443`) | number | `0` | no |
-| instance_count | Number of data nodes in the cluster | number | `4` | no |
-| instance_type | Elasticsearch instance type for data nodes in the cluster | string | `t2.small.elasticsearch` | no |
-| kibana_subdomain_name | The name of the subdomain for Kibana in the DNS zone (_e.g._ `kibana`, `ui`, `ui-es`, `search-ui`, `kibana.elasticsearch`) | string | `kibana` | no |
-| label_order | The naming order of the id output and Name tag | list(string) | `<list>` | no |
-| log_publishing_application_cloudwatch_log_group_arn | ARN of the CloudWatch log group to which log for ES_APPLICATION_LOGS needs to be published | string | `` | no |
-| log_publishing_application_enabled | Specifies whether log publishing option for ES_APPLICATION_LOGS is enabled or not | bool | `false` | no |
-| log_publishing_index_cloudwatch_log_group_arn | ARN of the CloudWatch log group to which log for INDEX_SLOW_LOGS needs to be published | string | `` | no |
-| log_publishing_index_enabled | Specifies whether log publishing option for INDEX_SLOW_LOGS is enabled or not | bool | `false` | no |
-| log_publishing_search_cloudwatch_log_group_arn | ARN of the CloudWatch log group to which log for SEARCH_SLOW_LOGS needs to be published | string | `` | no |
-| log_publishing_search_enabled | Specifies whether log publishing option for SEARCH_SLOW_LOGS is enabled or not | bool | `false` | no |
-| name | Solution name, e.g. 'app' or 'jenkins' | string | `` | no |
-| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | string | `` | no |
-| node_to_node_encryption_enabled | Whether to enable node-to-node encryption | bool | `false` | no |
-| security_groups | List of security group IDs to be allowed to connect to the cluster | list(string) | `<list>` | no |
-| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |
-| subnet_ids | VPC Subnet IDs | list(string) | `<list>` | no |
-| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | map(string) | `<map>` | no |
-| vpc_enabled | Set to false if ES should be deployed outside of VPC. | bool | `true` | no |
-| vpc_id | VPC ID | string | `null` | no |
-| zone_awareness_enabled | Enable zone awareness for Elasticsearch cluster | bool | `true` | no |
+|------|-------------|------|---------|:--------:|
+| advanced\_options | Key-value string pairs to specify advanced configuration options | `map(string)` | `{}` | no |
+| allowed\_cidr\_blocks | List of CIDR blocks to be allowed to connect to the cluster | `list(string)` | `[]` | no |
+| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| automated\_snapshot\_start\_hour | Hour at which automated snapshots are taken, in UTC | `number` | `0` | no |
+| availability\_zone\_count | Number of Availability Zones for the domain to use. | `number` | `2` | no |
+| cognito\_authentication\_enabled | Whether to enable Amazon Cognito authentication with Kibana | `bool` | `false` | no |
+| cognito\_iam\_role\_arn | ARN of the IAM role that has the AmazonESCognitoAccess policy attached | `string` | `""` | no |
+| cognito\_identity\_pool\_id | The ID of the Cognito Identity Pool to use | `string` | `""` | no |
+| cognito\_user\_pool\_id | The ID of the Cognito User Pool to use | `string` | `""` | no |
+| create\_iam\_service\_linked\_role | Whether to create `AWSServiceRoleForAmazonElasticsearchService` service-linked role. Set it to `false` if you already have an ElasticSearch cluster created in the AWS account and AWSServiceRoleForAmazonElasticsearchService already exists. See https://github.com/terraform-providers/terraform-provider-aws/issues/5218 for more info | `bool` | `true` | no |
+| dedicated\_master\_count | Number of dedicated master nodes in the cluster | `number` | `0` | no |
+| dedicated\_master\_enabled | Indicates whether dedicated master nodes are enabled for the cluster | `bool` | `false` | no |
+| dedicated\_master\_type | Instance type of the dedicated master nodes in the cluster | `string` | `"t2.small.elasticsearch"` | no |
+| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
+| dns\_zone\_id | Route53 DNS Zone ID to add hostname records for Elasticsearch domain and Kibana | `string` | `""` | no |
+| ebs\_iops | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | `number` | `0` | no |
+| ebs\_volume\_size | EBS volumes for data storage in GB | `number` | `0` | no |
+| ebs\_volume\_type | Storage type of EBS volumes | `string` | `"gp2"` | no |
+| elasticsearch\_subdomain\_name | The name of the subdomain for Elasticsearch in the DNS zone (\_e.g.\_ `elasticsearch`, `ui`, `ui-es`, `search-ui`) | `string` | `""` | no |
+| elasticsearch\_version | Version of Elasticsearch to deploy (\_e.g.\_ `7.4`, `7.1`, `6.8`, `6.7`, `6.5`, `6.4`, `6.3`, `6.2`, `6.0`, `5.6`, `5.5`, `5.3`, `5.1`, `2.3`, `1.5` | `string` | `"7.4"` | no |
+| enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
+| encrypt\_at\_rest\_enabled | Whether to enable encryption at rest | `bool` | `true` | no |
+| encrypt\_at\_rest\_kms\_key\_id | The KMS key ID to encrypt the Elasticsearch domain with. If not specified, then it defaults to using the AWS/Elasticsearch service KMS key | `string` | `""` | no |
+| environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
+| iam\_actions | List of actions to allow for the IAM roles, _e.g._ `es:ESHttpGet`, `es:ESHttpPut`, `es:ESHttpPost` | `list(string)` | `[]` | no |
+| iam\_authorizing\_role\_arns | List of IAM role ARNs to permit to assume the Elasticsearch user role | `list(string)` | `[]` | no |
+| iam\_role\_arns | List of IAM role ARNs to permit access to the Elasticsearch domain | `list(string)` | `[]` | no |
+| iam\_role\_max\_session\_duration | The maximum session duration (in seconds) for the user role. Can have a value from 1 hour to 12 hours | `number` | `3600` | no |
+| ingress\_port\_range\_end | End number for allowed port range. (e.g. `443`) | `number` | `65535` | no |
+| ingress\_port\_range\_start | Start number for allowed port range. (e.g. `443`) | `number` | `0` | no |
+| instance\_count | Number of data nodes in the cluster | `number` | `4` | no |
+| instance\_type | Elasticsearch instance type for data nodes in the cluster | `string` | `"t2.small.elasticsearch"` | no |
+| kibana\_subdomain\_name | The name of the subdomain for Kibana in the DNS zone (\_e.g.\_ `kibana`, `ui`, `ui-es`, `search-ui`, `kibana.elasticsearch`) | `string` | `"kibana"` | no |
+| label\_order | The naming order of the id output and Name tag | `list(string)` | `[]` | no |
+| log\_publishing\_application\_cloudwatch\_log\_group\_arn | ARN of the CloudWatch log group to which log for ES\_APPLICATION\_LOGS needs to be published | `string` | `""` | no |
+| log\_publishing\_application\_enabled | Specifies whether log publishing option for ES\_APPLICATION\_LOGS is enabled or not | `bool` | `false` | no |
+| log\_publishing\_index\_cloudwatch\_log\_group\_arn | ARN of the CloudWatch log group to which log for INDEX\_SLOW\_LOGS needs to be published | `string` | `""` | no |
+| log\_publishing\_index\_enabled | Specifies whether log publishing option for INDEX\_SLOW\_LOGS is enabled or not | `bool` | `false` | no |
+| log\_publishing\_search\_cloudwatch\_log\_group\_arn | ARN of the CloudWatch log group to which log for SEARCH\_SLOW\_LOGS needs to be published | `string` | `""` | no |
+| log\_publishing\_search\_enabled | Specifies whether log publishing option for SEARCH\_SLOW\_LOGS is enabled or not | `bool` | `false` | no |
+| name | Solution name, e.g. 'app' or 'jenkins' | `string` | `""` | no |
+| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
+| node\_to\_node\_encryption\_enabled | Whether to enable node-to-node encryption | `bool` | `false` | no |
+| security\_groups | List of security group IDs to be allowed to connect to the cluster | `list(string)` | `[]` | no |
+| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `""` | no |
+| subnet\_ids | VPC Subnet IDs | `list(string)` | `[]` | no |
+| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| vpc\_enabled | Set to false if ES should be deployed outside of VPC. | `bool` | `true` | no |
+| vpc\_id | VPC ID | `string` | `null` | no |
+| zone\_awareness\_enabled | Enable zone awareness for Elasticsearch cluster | `bool` | `true` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| domain_arn | ARN of the Elasticsearch domain |
-| domain_endpoint | Domain-specific endpoint used to submit index, search, and data upload requests |
-| domain_hostname | Elasticsearch domain hostname to submit index, search, and data upload requests |
-| domain_id | Unique identifier for the Elasticsearch domain |
-| domain_name | Name of the Elasticsearch domain |
-| elasticsearch_user_iam_role_arn | The ARN of the IAM role to allow access to Elasticsearch cluster |
-| elasticsearch_user_iam_role_name | The name of the IAM role to allow access to Elasticsearch cluster |
-| kibana_endpoint | Domain-specific endpoint for Kibana without https scheme |
-| kibana_hostname | Kibana hostname |
-| security_group_id | Security Group ID to control access to the Elasticsearch domain |
+| domain\_arn | ARN of the Elasticsearch domain |
+| domain\_endpoint | Domain-specific endpoint used to submit index, search, and data upload requests |
+| domain\_hostname | Elasticsearch domain hostname to submit index, search, and data upload requests |
+| domain\_id | Unique identifier for the Elasticsearch domain |
+| domain\_name | Name of the Elasticsearch domain |
+| elasticsearch\_user\_iam\_role\_arn | The ARN of the IAM role to allow access to Elasticsearch cluster |
+| elasticsearch\_user\_iam\_role\_name | The name of the IAM role to allow access to Elasticsearch cluster |
+| kibana\_endpoint | Domain-specific endpoint for Kibana without https scheme |
+| kibana\_hostname | Kibana hostname |
+| security\_group\_id | Security Group ID to control access to the Elasticsearch domain |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -49,9 +49,9 @@
 | node_to_node_encryption_enabled | Whether to enable node-to-node encryption | bool | `false` | no |
 | security_groups | List of security group IDs to be allowed to connect to the cluster | list(string) | `<list>` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |
-| subnet_ids | Subnet IDs | list(string) | - | yes |
+| subnet_ids | Subnet IDs | list(string) | `<list>` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | map(string) | `<map>` | no |
-| vpc_id | VPC ID | string | - | yes |
+| vpc_id | VPC ID | string | `` | no |
 | zone_awareness_enabled | Enable zone awareness for Elasticsearch cluster | bool | `true` | no |
 
 ## Outputs

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  region = "us-east-2"
+}
+
 module "elasticsearch" {
   source                  = "../../"
   namespace               = "eg"
@@ -17,6 +21,6 @@ module "elasticsearch" {
   kibana_subdomain_name   = "kibana-es"
 
   advanced_options = {
-    rest.action.multi.allow_explicit_index = "true"
+    "rest.action.multi.allow_explicit_index" = "true"
   }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.7.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.10.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -11,7 +11,7 @@ module "vpc" {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.0"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.19.0"
   availability_zones   = var.availability_zones
   namespace            = var.namespace
   stage                = var.stage

--- a/examples/non_vpc/main.tf
+++ b/examples/non_vpc/main.tf
@@ -1,0 +1,22 @@
+module "elasticsearch" {
+  source                  = "../../"
+  namespace               = "eg"
+  stage                   = "dev"
+  name                    = "es"
+  dns_zone_id             = "Z14EN2YD427LRQ"
+  security_groups         = ["sg-XXXXXXXXX", "sg-YYYYYYYY"]
+  vpc_id                  = "vpc-XXXXXXXXX"
+  subnet_ids              = ["subnet-XXXXXXXXX", "subnet-YYYYYYYY"]
+  zone_awareness_enabled  = "true"
+  elasticsearch_version   = "6.5"
+  instance_type           = "t2.small.elasticsearch"
+  instance_count          = 4
+  iam_role_arns           = ["arn:aws:iam::XXXXXXXXX:role/ops", "arn:aws:iam::XXXXXXXXX:role/dev"]
+  iam_actions             = ["es:ESHttpGet", "es:ESHttpPut", "es:ESHttpPost"]
+  encrypt_at_rest_enabled = "true"
+  kibana_subdomain_name   = "kibana-es"
+
+  advanced_options = {
+    rest.action.multi.allow_explicit_index = "true"
+  }
+}

--- a/examples/non_vpc/main.tf
+++ b/examples/non_vpc/main.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  region = "us-east-2"
+}
+
 module "elasticsearch" {
   source                  = "../../"
   namespace               = "eg"
@@ -5,8 +9,7 @@ module "elasticsearch" {
   name                    = "es"
   dns_zone_id             = "Z14EN2YD427LRQ"
   security_groups         = ["sg-XXXXXXXXX", "sg-YYYYYYYY"]
-  vpc_id                  = "vpc-XXXXXXXXX"
-  subnet_ids              = ["subnet-XXXXXXXXX", "subnet-YYYYYYYY"]
+  vpc_enabled             = false
   zone_awareness_enabled  = "true"
   elasticsearch_version   = "6.5"
   instance_type           = "t2.small.elasticsearch"
@@ -17,6 +20,6 @@ module "elasticsearch" {
   kibana_subdomain_name   = "kibana-es"
 
   advanced_options = {
-    rest.action.multi.allow_explicit_index = "true"
+    "rest.action.multi.allow_explicit_index" = "true"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "aws_security_group_rule" "ingress_security_groups" {
 }
 
 resource "aws_security_group_rule" "ingress_cidr_blocks" {
-  count             = var.enabled && var.vpc_enabled && var.allowed_cidr_blocks != [] ? 1 : 0
+  count             = var.enabled && var.vpc_enabled && length(var.allowed_cidr_blocks) > 0 ? 1 : 0
   description       = "Allow inbound traffic from CIDR blocks"
   type              = "ingress"
   from_port         = var.ingress_port_range_start

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "aws_security_group_rule" "ingress_security_groups" {
 }
 
 resource "aws_security_group_rule" "ingress_cidr_blocks" {
-  count             = var.enabled && var.vpc_enabled ? 1 : 0
+  count             = var.enabled && var.vpc_enabled && var.allowed_cidr_blocks != [] ? 1 : 0
   description       = "Allow inbound traffic from CIDR blocks"
   type              = "ingress"
   from_port         = var.ingress_port_range_start

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ module "user_label" {
 }
 
 resource "aws_security_group" "default" {
-  count       = var.enabled ? 1 : 0
+  count       = var.enabled && var.vpc_id != "" ? 1 : 0
   vpc_id      = var.vpc_id
   name        = module.label.id
   description = "Allow inbound traffic from Security Groups and CIDRs. Allow all outbound traffic"
@@ -33,7 +33,7 @@ resource "aws_security_group" "default" {
 }
 
 resource "aws_security_group_rule" "ingress_security_groups" {
-  count                    = var.enabled ? length(var.security_groups) : 0
+  count                    = var.enabled && var.vpc_id != "" ? length(var.security_groups) : 0
   description              = "Allow inbound traffic from Security Groups"
   type                     = "ingress"
   from_port                = var.ingress_port_range_start
@@ -44,7 +44,7 @@ resource "aws_security_group_rule" "ingress_security_groups" {
 }
 
 resource "aws_security_group_rule" "ingress_cidr_blocks" {
-  count             = var.enabled && length(var.allowed_cidr_blocks) > 0 ? 1 : 0
+  count             = var.enabled && var.vpc_id != "" && length(var.allowed_cidr_blocks) > 0 ? 1 : 0
   description       = "Allow inbound traffic from CIDR blocks"
   type              = "ingress"
   from_port         = var.ingress_port_range_start
@@ -55,7 +55,7 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "egress" {
-  count             = var.enabled ? 1 : 0
+  count             = var.enabled && var.vpc_id != "" ? 1 : 0
   description       = "Allow all egress traffic"
   type              = "egress"
   from_port         = 0
@@ -163,9 +163,13 @@ resource "aws_elasticsearch_domain" "default" {
     enabled = var.node_to_node_encryption_enabled
   }
 
-  vpc_options {
-    security_group_ids = [join("", aws_security_group.default.*.id)]
-    subnet_ids         = var.subnet_ids
+  dynamic "vpc_options" {
+    for_each = var.subnet_ids
+
+    content {
+      security_group_ids = [join("", aws_security_group.default.*.id)]
+      subnet_ids         = var.subnet_ids
+    }
   }
 
   snapshot_options {

--- a/main.tf
+++ b/main.tf
@@ -164,7 +164,7 @@ resource "aws_elasticsearch_domain" "default" {
   }
 
   dynamic "vpc_options" {
-    for_each = var.subnet_ids
+    for_each = var.vpc_enabled ? [true] : []
 
     content {
       security_group_ids = [join("", aws_security_group.default.*.id)]

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ module "user_label" {
 }
 
 resource "aws_security_group" "default" {
-  count       = var.enabled && var.vpc_id != "" ? 1 : 0
+  count       = var.enabled && var.vpc_enabled ? 1 : 0
   vpc_id      = var.vpc_id
   name        = module.label.id
   description = "Allow inbound traffic from Security Groups and CIDRs. Allow all outbound traffic"
@@ -33,7 +33,7 @@ resource "aws_security_group" "default" {
 }
 
 resource "aws_security_group_rule" "ingress_security_groups" {
-  count                    = var.enabled && var.vpc_id != "" ? length(var.security_groups) : 0
+  count                    = var.enabled && var.vpc_enabled ? length(var.security_groups) : 0
   description              = "Allow inbound traffic from Security Groups"
   type                     = "ingress"
   from_port                = var.ingress_port_range_start
@@ -44,7 +44,7 @@ resource "aws_security_group_rule" "ingress_security_groups" {
 }
 
 resource "aws_security_group_rule" "ingress_cidr_blocks" {
-  count             = var.enabled && var.vpc_id != "" && length(var.allowed_cidr_blocks) > 0 ? 1 : 0
+  count             = var.enabled && var.vpc_enabled ? 1 : 0
   description       = "Allow inbound traffic from CIDR blocks"
   type              = "ingress"
   from_port         = var.ingress_port_range_start
@@ -55,7 +55,7 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "egress" {
-  count             = var.enabled && var.vpc_id != "" ? 1 : 0
+  count             = var.enabled && var.vpc_enabled ? 1 : 0
   description       = "Allow all egress traffic"
   type              = "egress"
   from_port         = 0
@@ -233,7 +233,7 @@ resource "aws_elasticsearch_domain_policy" "default" {
 module "domain_hostname" {
   source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.3.0"
   enabled = var.enabled && var.dns_zone_id != "" ? true : false
-  name    = "${var.elasticsearch_subdomain_name == "" ? var.name : var.elasticsearch_subdomain_name}"
+  name    = var.elasticsearch_subdomain_name == "" ? var.name : var.elasticsearch_subdomain_name
   ttl     = 60
   zone_id = var.dns_zone_id
   records = [join("", aws_elasticsearch_domain.default.*.endpoint)]

--- a/variables.tf
+++ b/variables.tf
@@ -102,8 +102,8 @@ variable "dns_zone_id" {
 
 variable "elasticsearch_version" {
   type        = string
-  default     = "6.8"
-  description = "Version of Elasticsearch to deploy (_e.g._ `7.1`, `6.8`, `6.7`, `6.5`, `6.4`, `6.3`, `6.2`, `6.0`, `5.6`, `5.5`, `5.3`, `5.1`, `2.3`, `1.5`"
+  default     = "7.4"
+  description = "Version of Elasticsearch to deploy (_e.g._ `7.4`, `7.1`, `6.8`, `6.7`, `6.5`, `6.4`, `6.3`, `6.2`, `6.0`, `5.6`, `5.5`, `5.3`, `5.1`, `2.3`, `1.5`"
 }
 
 variable "instance_type" {

--- a/variables.tf
+++ b/variables.tf
@@ -76,15 +76,21 @@ variable "allowed_cidr_blocks" {
   description = "List of CIDR blocks to be allowed to connect to the cluster"
 }
 
+variable "vpc_enabled" {
+  type        = bool
+  description = "Set to false if ES should be deployed outside of VPC."
+  default     = true
+}
+
 variable "vpc_id" {
   type        = string
   description = "VPC ID"
-  default     = ""
+  default     = null
 }
 
 variable "subnet_ids" {
   type        = list(string)
-  description = "Subnet IDs"
+  description = "VPC Subnet IDs"
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -79,13 +79,13 @@ variable "allowed_cidr_blocks" {
 variable "vpc_id" {
   type        = string
   description = "VPC ID"
-  default = ""
+  default     = ""
 }
 
 variable "subnet_ids" {
   type        = list(string)
   description = "Subnet IDs"
-  default = []
+  default     = []
 }
 
 variable "dns_zone_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -79,11 +79,13 @@ variable "allowed_cidr_blocks" {
 variable "vpc_id" {
   type        = string
   description = "VPC ID"
+  default = ""
 }
 
 variable "subnet_ids" {
   type        = list(string)
   description = "Subnet IDs"
+  default = []
 }
 
 variable "dns_zone_id" {


### PR DESCRIPTION
## what
* ES can be used outside of VPC

## why
* For currently supported Kinesis Firehose delivery to ElasticSearch (VPC delivery is available in AWS but not yet in `tf`) 

## references
* https://github.com/terraform-providers/terraform-provider-aws/issues/13015