### PR TITLE
Dynamic cognito_options inner block to avoid permission problems in AWS China

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,22 +312,24 @@ Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 See [LICENSE](LICENSE) for full details.
 
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
+```text
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
-      https://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+```
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -176,11 +176,14 @@ resource "aws_elasticsearch_domain" "default" {
     automated_snapshot_start_hour = var.automated_snapshot_start_hour
   }
 
-  cognito_options {
-    enabled          = var.cognito_authentication_enabled
-    user_pool_id     = var.cognito_user_pool_id
-    identity_pool_id = var.cognito_identity_pool_id
-    role_arn         = var.cognito_iam_role_arn
+  dynamic "cognito_options" {
+    for_each = var.cognito_authentication_enabled ? [true] : []
+    content {
+      enabled          = true
+      user_pool_id     = var.cognito_user_pool_id
+      identity_pool_id = var.cognito_identity_pool_id
+      role_arn         = var.cognito_iam_role_arn
+    }
   }
 
   log_publishing_options {


### PR DESCRIPTION
## what
- Amazon Cognito authentication for Kibana is not supported on AWS China.
- Therefore we need to have a way to avoid setting the cognito options inner block on the `aws_elasticsearch_domain` terraform resource.

## why
- When we try to run this module on AWS China we always get the following error:

```
Error: Error creating ElasticSearch domain: DisabledOperationException: You don’t have permissions to integrate with Cognito. Contact your admin if you need help.
on .terraform/modules/elasticsearch/terraform-aws-elasticsearch-0.18.0/main.tf line 122, in resource 
"aws_elasticsearch_domain" "default": 122: resource "aws_elasticsearch_domain" "default" {
```

Even though we tried to set the correct IAM roles (see references below) and permissions the error still occurs.

## references
* https://docs.amazonaws.cn/en_us/aws/latest/userguide/elasticsearch.html
* https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-cognito-auth.html#es-cognito-auth-config

