### PR TITLE
Set ebs volume size for basic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ module "elasticsearch" {
   elasticsearch_version   = "6.5"
   instance_type           = "t2.small.elasticsearch"
   instance_count          = 4
+  ebs_volume_size         = 10
   iam_role_arns           = ["arn:aws:iam::XXXXXXXXX:role/ops", "arn:aws:iam::XXXXXXXXX:role/dev"]
   iam_actions             = ["es:ESHttpGet", "es:ESHttpPut", "es:ESHttpPost"]
   encrypt_at_rest_enabled = true

--- a/README.yaml
+++ b/README.yaml
@@ -63,6 +63,7 @@ usage: |-
     elasticsearch_version   = "6.5"
     instance_type           = "t2.small.elasticsearch"
     instance_count          = 4
+    ebs_volume_size         = 10
     iam_role_arns           = ["arn:aws:iam::XXXXXXXXX:role/ops", "arn:aws:iam::XXXXXXXXX:role/dev"]
     iam_actions             = ["es:ESHttpGet", "es:ESHttpPut", "es:ESHttpPost"]
     encrypt_at_rest_enabled = true

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -15,6 +15,7 @@ module "elasticsearch" {
   elasticsearch_version   = "6.5"
   instance_type           = "t2.small.elasticsearch"
   instance_count          = 4
+  ebs_volume_size         = 10
   iam_role_arns           = ["arn:aws:iam::XXXXXXXXX:role/ops", "arn:aws:iam::XXXXXXXXX:role/dev"]
   iam_actions             = ["es:ESHttpGet", "es:ESHttpPut", "es:ESHttpPost"]
   encrypt_at_rest_enabled = "true"


### PR DESCRIPTION
## what
* Setting EBS volume size of 10 for basic example 

## why
* Terraform apply is failing on 
```
Error: Error creating ElasticSearch domain: ValidationException: EBS storage must be selected for t2.small.elasticsearch
```
as this is currently being defaulted to 0 https://github.com/cloudposse/terraform-aws-elasticsearch/blob/master/variables.tf#L154

## references
* https://github.com/cloudposse/terraform-aws-elasticsearch/blob/master/main.tf#L130

