### PR TITLE
Fixes kibana_hostname module using incorrect endpoint output

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -262,5 +262,5 @@ module "kibana_hostname" {
   name    = var.kibana_subdomain_name
   ttl     = 60
   zone_id = var.dns_zone_id
-  records = [join("", aws_elasticsearch_domain.default.*.endpoint)]
+  records = [join("", aws_elasticsearch_domain.default.*.kibana_endpoint)]
 }


### PR DESCRIPTION
## what
* Fixes kibana_hostname module using incorrect endpoint for hostname binding. It was using the root endpoint and not the kibana endpoint. 

## why
* So the ES cluster's kibana hostname points to the correct address.

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain

