### PR TITLE
Update terraform-aws-route53-cluster-hostname versions to support Ter…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -248,7 +248,7 @@ resource "aws_elasticsearch_domain_policy" "default" {
 }
 
 module "domain_hostname" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.3.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.5.0"
   enabled = var.enabled && var.dns_zone_id != "" ? true : false
   name    = var.elasticsearch_subdomain_name == "" ? var.name : var.elasticsearch_subdomain_name
   ttl     = 60
@@ -257,7 +257,7 @@ module "domain_hostname" {
 }
 
 module "kibana_hostname" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.3.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.5.0"
   enabled = var.enabled && var.dns_zone_id != "" ? true : false
   name    = var.kibana_subdomain_name
   ttl     = 60


### PR DESCRIPTION
…raform 0.13

## what
* Update referenced module version so that we don't get a version conflict when using TF 0.13

## why
* Currently I get the following error message when running `terraform init`:
```
Error: Unsupported Terraform Core version

  on .terraform/modules/my.module.elasticsearch.kibana_hostname/versions.tf line 2, in terraform:
   2:   required_version = "~> 0.12.0"
```

## references
* Similar to #66 by @Gowiem a few days ago, the referenced module has been updated to support TF 0.13 but this module is using an outdated version.
