### PR TITLE
Aws provider 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
+| terraform | >= 0.12.0 |
 | aws | >= 2.0 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |

--- a/README.md
+++ b/README.md
@@ -124,12 +124,13 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
 
@@ -137,7 +138,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | null | ~> 2.0 |
 
 ## Inputs
@@ -213,6 +214,7 @@ Available targets:
 | kibana\_hostname | Kibana hostname |
 | security\_group\_id | Security Group ID to control access to the Elasticsearch domain |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,9 +1,10 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
 
@@ -11,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | null | ~> 2.0 |
 
 ## Inputs
@@ -87,3 +88,4 @@
 | kibana\_hostname | Kibana hostname |
 | security\_group\_id | Security Group ID to control access to the Elasticsearch domain |
 
+<!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
+| terraform | >= 0.12.0 |
 | aws | >= 2.0 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.10.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.17.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -11,7 +11,7 @@ module "vpc" {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.19.0"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.30.0"
   availability_zones   = var.availability_zones
   namespace            = var.namespace
   stage                = var.stage

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
+  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
   enabled     = var.enabled
   namespace   = var.namespace
   name        = var.name
@@ -12,7 +12,7 @@ module "label" {
 }
 
 module "user_label" {
-  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
+  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
   enabled     = var.enabled
   namespace   = var.namespace
   name        = var.name
@@ -248,7 +248,7 @@ resource "aws_elasticsearch_domain_policy" "default" {
 }
 
 module "domain_hostname" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.5.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
   enabled = var.enabled && var.dns_zone_id != "" ? true : false
   name    = var.elasticsearch_subdomain_name == "" ? var.name : var.elasticsearch_subdomain_name
   ttl     = 60
@@ -257,7 +257,7 @@ module "domain_hostname" {
 }
 
 module "kibana_hostname" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.5.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
   enabled = var.enabled && var.dns_zone_id != "" ? true : false
   name    = var.kibana_subdomain_name
   ttl     = 60

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
     aws      = ">= 2.0"

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws      = "~> 2.0"
+    aws      = ">= 2.0"
     template = "~> 2.0"
     null     = "~> 2.0"
   }


### PR DESCRIPTION
## what
* enable 3.x AWS provider versions to be used with this module

## why
* latest version should be used, 2.x not getting updates any more
* other modules you guys are providing are mostly (?) using 3.x already