### PR TITLE
Allow authenticated access from anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ Available targets:
 | Name | Version |
 |------|---------|
 | aws | >= 2.0 |
-| null | >= 2.0 |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,7 +13,6 @@
 | Name | Version |
 |------|---------|
 | aws | >= 2.0 |
-| null | >= 2.0 |
 
 ## Inputs
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -10,9 +10,9 @@ name = "es-test"
 
 availability_zones = ["us-east-2a", "us-east-2b"]
 
-instance_type = "t2.small.elasticsearch"
+instance_type = "t3.small.elasticsearch"
 
-elasticsearch_version = "6.5"
+elasticsearch_version = "7.7"
 
 instance_count = 2
 
@@ -26,7 +26,7 @@ elasticsearch_subdomain_name = ""
 
 kibana_subdomain_name = ""
 
-ebs_volume_size = 10
+ebs_volume_size = 20
 
 create_iam_service_linked_role = false
 

--- a/main.tf
+++ b/main.tf
@@ -276,7 +276,7 @@ module "kibana_hostname" {
   # Note: kibana_endpoint is not just a domain name, it includes a path component,
   # and as such is not suitable for a DNS record. The plain endpoint is the
   # hostname portion and should be used for DNS.
-  records  = [join("", aws_elasticsearch_domain.default.*.endpoint)]
+  records = [join("", aws_elasticsearch_domain.default.*.endpoint)]
 
   context = module.this.context
 }

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,7 @@
 module "user_label" {
   source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
 
-  enabled    = module.this.enabled
-  attributes = concat(module.this.attributes, ["user"])
+  attributes = compact(concat(module.this.attributes, ["user"]))
 
   context = module.this.context
 }
@@ -10,8 +9,7 @@ module "user_label" {
 module "kibana_label" {
   source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
 
-  enabled    = module.this.enabled
-  attributes = concat(module.this.attributes, ["kibana"])
+  attributes = compact(concat(module.this.attributes, ["kibana"]))
 
   context = module.this.context
 }
@@ -97,20 +95,6 @@ data "aws_iam_policy_document" "assume_role" {
   }
 }
 
-# inspired by https://github.com/hashicorp/terraform/issues/20692
-# I use 0.12 new "dynamic" block - https://www.terraform.io/docs/configuration/expressions.html
-# If we have 1 az - the count of this resource equals 0, hence no config
-# block appears in the `aws_elasticsearch_domain`
-# If we have more than 1 - we set the trigger to the actual value of
-# `availability_zone_count`
-# and `dynamic` block kicks in
-resource "null_resource" "azs" {
-  count = var.availability_zone_count > 1 ? 1 : 0
-  triggers = {
-    availability_zone_count = var.availability_zone_count
-  }
-}
-
 resource "aws_elasticsearch_domain" "default" {
   count                 = module.this.enabled ? 1 : 0
   domain_name           = module.this.id
@@ -153,13 +137,13 @@ resource "aws_elasticsearch_domain" "default" {
     dedicated_master_type    = var.dedicated_master_type
     zone_awareness_enabled   = var.zone_awareness_enabled
     warm_enabled             = var.warm_enabled
-    warm_count               = var.warm_count
-    warm_type                = var.warm_type
+    warm_count               = var.warm_enabled ? var.warm_count : null
+    warm_type                = var.warm_enabled ? var.warm_type : null
 
     dynamic "zone_awareness_config" {
-      for_each = null_resource.azs[*].triggers
+      for_each = var.availability_zone_count > 1 ? [true] : []
       content {
-        availability_zone_count = zone_awareness_config.value.availability_zone_count
+        availability_zone_count = var.availability_zone_count
       }
     }
   }
@@ -218,6 +202,9 @@ data "aws_iam_policy_document" "default" {
   count = module.this.enabled && (length(var.iam_authorizing_role_arns) > 0 || length(var.iam_role_arns) > 0) ? 1 : 0
 
   statement {
+    sid    = "AllowEsAccessToSpecifiedRoles"
+    effect = "Allow"
+
     actions = distinct(compact(var.iam_actions))
 
     resources = [
@@ -229,14 +216,30 @@ data "aws_iam_policy_document" "default" {
       type        = "AWS"
       identifiers = distinct(compact(concat(var.iam_role_arns, aws_iam_role.elasticsearch_user.*.arn)))
     }
+  }
 
-    # This condition is for non VPC ES to allow anonymous access from whitelisted IP ranges without requests signing
-    # https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-ac.html#es-ac-types-ip
-    # https://aws.amazon.com/premiumsupport/knowledge-center/anonymous-not-authorized-elasticsearch/
-    dynamic "condition" {
-      for_each = ! var.vpc_enabled && length(var.allowed_cidr_blocks) > 0 ? [true] : []
+  # This statement is for non VPC ES to allow anonymous access from whitelisted IP ranges without requests signing
+  # https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-ac.html#es-ac-types-ip
+  # https://aws.amazon.com/premiumsupport/knowledge-center/anonymous-not-authorized-elasticsearch/
+  dynamic "statement" {
+    for_each = length(var.allowed_cidr_blocks) > 0 && ! var.vpc_enabled ? [true] : []
+    content {
+      sid    = "AllowAnonymousEsAccessFromCIDR"
+      effect = "Allow"
 
-      content {
+      actions = distinct(compact(var.iam_actions))
+
+      resources = [
+        join("", aws_elasticsearch_domain.default.*.arn),
+        "${join("", aws_elasticsearch_domain.default.*.arn)}/*"
+      ]
+
+      principals {
+        type        = "AWS"
+        identifiers = ["*"]
+      }
+
+      condition {
         test     = "IpAddress"
         values   = var.allowed_cidr_blocks
         variable = "aws:SourceIp"

--- a/main.tf
+++ b/main.tf
@@ -273,7 +273,10 @@ module "kibana_hostname" {
   dns_name = var.kibana_subdomain_name == "" ? module.kibana_label.id : var.kibana_subdomain_name
   ttl      = 60
   zone_id  = var.dns_zone_id
-  records  = [join("", aws_elasticsearch_domain.default.*.kibana_endpoint)]
+  # Note: kibana_endpoint is not just a domain name, it includes a path component,
+  # and as such is not suitable for a DNS record. The plain endpoint is the
+  # hostname portion and should be used for DNS.
+  records  = [join("", aws_elasticsearch_domain.default.*.endpoint)]
 
   context = module.this.context
 }


### PR DESCRIPTION
## what

1. Allow authenticated access from anywhere
2. Avoid specifying `warm_count` and `warm_type` when `warm_enabled == false`
3. Revert PR #66
3. Minor cleanups

## why

1. PR #58 allowed unauthenticated access from whitelisted CIDRs, but in the process restricted authenticated access to those IPs as well. This PR make authenticated access not subject to the CIDR restriction.
2. PR #74 introduced support for UltraWarm clusters, but always set `warm_count` and `warm_type`, eve when `warm_enabled == false`. This caused Terraform to always see the state as needing updating, since the detected state when `warm_enabled == false` is `warm_count = 0` and `warm_type` unset. The PR leaves them unset to avoid apparent drift.
3.   The `kibana_endpoint` is not just a domain name, it includes a path component, the end result being something like `esdomain-ntzuxwxpuxm7dmxcbpy4slbc4u.us-west-1.es.amazonaws.com/_plugin/kibana/`. As such, is not suitable for a DNS record. The plain `endpoint` is the hostname portion and should be used for DNS. The previous code was correct but misunderstood.

3. Some working code was nevertheless not the best style, and to the extent this serves as an example, we want the code to be in our preferred style.