### PR TITLE
Upgrade AWS Provider Version to 3.8

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.8"
     }
     template = {
       source  = "hashicorp/template"


### PR DESCRIPTION
This is the oldest version that supports `AUDIT_LOG`.

Fixes #93 

> Introduced by #86, the option to add AUDIT_LOGGING is not compatible with all >= 2.0 AWS providers.
    Which leads to :
    
    Error: expected log_publishing_options.0.log_type to be one of [INDEX_SLOW_LOGS SEARCH_SLOW_LOGS ES_APPLICATION_LOGS], got AUDIT_LOGS
    
      on .terraform/modules/elasticsearch/main.tf line 100, in resource "aws_elasticsearch_domain" "default":
     100: resource "aws_elasticsearch_domain" "default" {
    Enforcing a >=3 version in my wrapping module fixed it.
