### PR TITLE
domain_endpoint_options_enforce_https enabled by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 .terraform
 .idea
 *.iml
+**/.terraform.lock.hcl
+test.log
 
 **/.build-harness
 **/build-harness

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Available targets:
 | dedicated\_master\_type | Instance type of the dedicated master nodes in the cluster | `string` | `"t2.small.elasticsearch"` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | dns\_zone\_id | Route53 DNS Zone ID to add hostname records for Elasticsearch domain and Kibana | `string` | `""` | no |
-| domain\_endpoint\_options\_enforce\_https | Whether or not to require HTTPS | `bool` | `false` | no |
+| domain\_endpoint\_options\_enforce\_https | Whether or not to require HTTPS | `bool` | `true` | no |
 | domain\_endpoint\_options\_tls\_security\_policy | The name of the TLS security policy that needs to be applied to the HTTPS endpoint | `string` | `"Policy-Min-TLS-1-0-2019-07"` | no |
 | domain\_hostname\_enabled | Explicit flag to enable creating a DNS hostname for ES. If `true`, then `var.dns_zone_id` is required. | `bool` | `false` | no |
 | ebs\_iops | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | `number` | `0` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -41,7 +41,7 @@
 | dedicated\_master\_type | Instance type of the dedicated master nodes in the cluster | `string` | `"t2.small.elasticsearch"` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | dns\_zone\_id | Route53 DNS Zone ID to add hostname records for Elasticsearch domain and Kibana | `string` | `""` | no |
-| domain\_endpoint\_options\_enforce\_https | Whether or not to require HTTPS | `bool` | `false` | no |
+| domain\_endpoint\_options\_enforce\_https | Whether or not to require HTTPS | `bool` | `true` | no |
 | domain\_endpoint\_options\_tls\_security\_policy | The name of the TLS security policy that needs to be applied to the HTTPS endpoint | `string` | `"Policy-Min-TLS-1-0-2019-07"` | no |
 | domain\_hostname\_enabled | Explicit flag to enable creating a DNS hostname for ES. If `true`, then `var.dns_zone_id` is required. | `bool` | `false` | no |
 | ebs\_iops | The baseline input/output (I/O) performance of EBS volumes attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type | `number` | `0` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "vpc" {
   source  = "cloudposse/vpc/aws"
-  version = "0.17.0"
+  version = "0.18.2"
 
   cidr_block = "172.16.0.0/16"
 
@@ -13,7 +13,7 @@ module "vpc" {
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "0.30.0"
+  version = "0.34.0"
 
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id

--- a/main.tf
+++ b/main.tf
@@ -1,17 +1,17 @@
 module "user_label" {
   source  = "cloudposse/label/null"
-  version = "0.22.0"
+  version = "0.22.1"
 
-  attributes = compact(concat(module.this.attributes, ["user"]))
+  attributes = ["user"]
 
   context = module.this.context
 }
 
 module "kibana_label" {
   source  = "cloudposse/label/null"
-  version = "0.22.0"
+  version = "0.22.1"
 
-  attributes = compact(concat(module.this.attributes, ["kibana"]))
+  attributes = ["kibana"]
 
   context = module.this.context
 }
@@ -229,7 +229,7 @@ data "aws_iam_policy_document" "default" {
   # https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-ac.html#es-ac-types-ip
   # https://aws.amazon.com/premiumsupport/knowledge-center/anonymous-not-authorized-elasticsearch/
   dynamic "statement" {
-    for_each = length(var.allowed_cidr_blocks) > 0 && ! var.vpc_enabled ? [true] : []
+    for_each = length(var.allowed_cidr_blocks) > 0 && !var.vpc_enabled ? [true] : []
     content {
       effect = "Allow"
 
@@ -262,7 +262,7 @@ resource "aws_elasticsearch_domain_policy" "default" {
 
 module "domain_hostname" {
   source  = "cloudposse/route53-cluster-hostname/aws"
-  version = "0.8.0"
+  version = "0.10.0"
 
   enabled  = module.this.enabled && var.domain_hostname_enabled
   dns_name = var.elasticsearch_subdomain_name == "" ? module.this.id : var.elasticsearch_subdomain_name
@@ -275,7 +275,7 @@ module "domain_hostname" {
 
 module "kibana_hostname" {
   source  = "cloudposse/route53-cluster-hostname/aws"
-  version = "0.8.0"
+  version = "0.10.0"
 
   enabled  = module.this.enabled && var.kibana_hostname_enabled
   dns_name = var.kibana_subdomain_name == "" ? module.kibana_label.id : var.kibana_subdomain_name

--- a/main.tf
+++ b/main.tf
@@ -229,7 +229,7 @@ data "aws_iam_policy_document" "default" {
   # https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-ac.html#es-ac-types-ip
   # https://aws.amazon.com/premiumsupport/knowledge-center/anonymous-not-authorized-elasticsearch/
   dynamic "statement" {
-    for_each = length(var.allowed_cidr_blocks) > 0 && !var.vpc_enabled ? [true] : []
+    for_each = length(var.allowed_cidr_blocks) > 0 && ! var.vpc_enabled ? [true] : []
     content {
       effect = "Allow"
 

--- a/test/src/go.mod
+++ b/test/src/go.mod
@@ -3,6 +3,6 @@ module github.com/cloudposse/terraform-aws-elasticsearch
 go 1.14
 
 require (
-	github.com/gruntwork-io/terratest v0.30.0
+	github.com/gruntwork-io/terratest v0.31.4
 	github.com/stretchr/testify v1.6.1
 )

--- a/variables.tf
+++ b/variables.tf
@@ -144,7 +144,7 @@ variable "encrypt_at_rest_kms_key_id" {
 
 variable "domain_endpoint_options_enforce_https" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether or not to require HTTPS"
 }
 


### PR DESCRIPTION
## what
* BridgeCrew compliance checks fix
* readme updated
* default behaviour changed: `Elasticsearch Domain EnforceHTTPS ` enabled by default

## why
* To be able to position our modules as standards compliant
* stay in sync with code
* To comply BridgeCrew check

## references
* https://docs.bridgecrew.io/docs/elasticsearch_6
