### PR TITLE
set security group lifecycle

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,10 @@ resource "aws_security_group" "default" {
   name        = module.this.id
   description = "Allow inbound traffic from Security Groups and CIDRs. Allow all outbound traffic"
   tags        = module.this.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "ingress_security_groups" {


### PR DESCRIPTION
## what

Added a lifecycle to the security group.

## why

While importing an existing resource-set to this module, if the SG had a different name, it will try to destroy the security group while attached to the cluster instances. The lifecycle optin will first create a new one, apply the change to the cluster and then destroy the unused SG.

## references
AWS doesn't allow security group to be renamed, Terraform will try to destroy and re-create it, it won't catch the error but will timeout trying to destroy a security group with attached interfaces.