### PR TITLE
feat: add validation to availability_zone_count

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -116,6 +116,11 @@ variable "availability_zone_count" {
   type        = number
   default     = 2
   description = "Number of Availability Zones for the domain to use."
+
+  validation {
+    condition     = contains([2, 3], var.availability_zone_count)
+    error_message = "The availibility zone count must be 2 or 3."
+  }
 }
 
 variable "ebs_volume_size" {


### PR DESCRIPTION
## what
* This ensures that availability_zone_count is only set to allowed values, see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#availability_zone_count.

## why
* Without this change, it’s possible to set `zone_awareness_enabled` to `true` which will automatically use 2 AZs, but set `availability_zone_count` to `1`, which is confusing

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#availability_zone_count.

