### PR TITLE
fix when awareness is disabled, always changing

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -152,7 +152,7 @@ resource "aws_elasticsearch_domain" "default" {
     warm_type                = var.warm_enabled ? var.warm_type : null
 
     dynamic "zone_awareness_config" {
-      for_each = var.availability_zone_count > 1 && var.zone_awareness_enabled == true ? [true] : []
+      for_each = var.availability_zone_count > 1 && var.zone_awareness_enabled ? [true] : []
       content {
         availability_zone_count = var.availability_zone_count
       }

--- a/main.tf
+++ b/main.tf
@@ -152,7 +152,7 @@ resource "aws_elasticsearch_domain" "default" {
     warm_type                = var.warm_enabled ? var.warm_type : null
 
     dynamic "zone_awareness_config" {
-      for_each = var.availability_zone_count > 1 ? [true] : []
+      for_each = var.availability_zone_count > 1 && var.zone_awareness_enabled == true ? [true] : []
       content {
         availability_zone_count = var.availability_zone_count
       }


### PR DESCRIPTION
## what
When we disable zone awareness, Terraform want to put in availability_zone_count on every single run,
so resource is always marked as changed.
This pull request fix this issue.

## why
Avoid unnecessary AWS calls and changes.
