### PR TITLE
Fix reference to var.auto_tune.cron_schedule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -179,7 +179,7 @@ resource "aws_elasticsearch_domain" "default" {
           value = var.auto_tune.duration
           unit  = "HOURS"
         }
-        cron_expression_for_recurrence = var.auto_tune_cron_schedule
+        cron_expression_for_recurrence = var.auto_tune.cron_schedule
       }
     }
   }


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- Small fix to the reference to the `var.auto_tune.cron_schedule` variable

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- The current variable reference is invalid because it has a small typo

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- closes #154 

