### PR TITLE
Updating validation blocking single-AZ ES clusters when Zone Awareness is disabled

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -122,11 +122,6 @@ variable "availability_zone_count" {
   type        = number
   default     = 2
   description = "Number of Availability Zones for the domain to use."
-
-  validation {
-    condition     = contains([2, 3], var.availability_zone_count)
-    error_message = "The availibility zone count must be 2 or 3."
-  }
 }
 
 variable "ebs_volume_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -122,6 +122,11 @@ variable "availability_zone_count" {
   type        = number
   default     = 2
   description = "Number of Availability Zones for the domain to use."
+
+  validation {
+    condition     = contains([2, 3], var.availability_zone_count) && var.zone_awareness_enabled == "true"
+    error_message = "The availibility zone count must be 2 or 3 when Zone Awareness is Enabled."
+  }
 }
 
 variable "ebs_volume_size" {


### PR DESCRIPTION
## what

Removing errant validation preventing the creation of Amazon OpenSearch Service ElasticSearch (ES) or OpenSearch (OS) clusters which live in a single Available Zone on Amazon Web Services (AWS)

Simple Process:
- You merge this PR
- You release a new version
- We can create clusters which live in one AZ
- Everyone wins

## why

Development and testing clusters may not want or need two or more Availability Zones for cost (among other reasons, but FinOps - saving money - is important) 

## references
https://github.com/cloudposse/terraform-aws-elasticsearch/issues/158

Identical errors in internal company environment

