### PR TITLE
Add var.create_elasticsearch_user_role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ resource "aws_iam_service_linked_role" "default" {
 
 # Role that pods can assume for access to elasticsearch and kibana
 resource "aws_iam_role" "elasticsearch_user" {
-  count              = module.this.enabled && (length(var.iam_authorizing_role_arns) > 0 || length(var.iam_role_arns) > 0) ? 1 : 0
+  count              = module.this.enabled && var.create_elasticsearch_user_role && (length(var.iam_authorizing_role_arns) > 0 || length(var.iam_role_arns) > 0) ? 1 : 0
   name               = module.user_label.id
   assume_role_policy = join("", data.aws_iam_policy_document.assume_role.*.json)
   description        = "IAM Role to assume to access the Elasticsearch ${module.this.id} cluster"

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "create_security_group" {
   description = "Whether to create a dedicated security group for the Elasticsearch domain. Set it to `false` if you already have security groups that you want to attach to the domain and specify them in the `security_groups` variable."
 }
 
+variable "create_elasticsearch_user_role" {
+  type        = bool
+  default     = true
+  description = "Whether to create an IAM role for Users/EC2 to assume to access the Elasticsearch domain. Set it to `false` if you already manage access through other means."
+}
+
 variable "ingress_port_range_start" {
   type        = number
   default     = 0


### PR DESCRIPTION
## what

* Add variable to control creation of aws_iam_role.elasticsearch_user

## why

* Resource not needed and can cause compliance issues

## references

closes #160 
