### PR TITLE
Fix Reference to Undeclared Variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -179,7 +179,7 @@ resource "aws_elasticsearch_domain" "default" {
           value = var.auto_tune.duration
           unit  = "HOURS"
         }
-        cron_expression_for_recurrence = var.auto_tune_cron_schedule
+        cron_expression_for_recurrence = var.auto_tune.cron_schedule
       }
     }
   }


### PR DESCRIPTION
## what
- Correct variable name for `var.auto_tune.cron_schedule`

## why
- `cron_expression_for_recurrence` referred to the wrong variable name, with `_` not `.`

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
