### PR TITLE
feat: support `multi_az_with_standby_enabled` for opensearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ Here are automated tests for the complete example using [bats](https://github.co
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.15.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.15.0 |
 
 ## Modules
 
@@ -230,6 +230,7 @@ Here are automated tests for the complete example using [bats](https://github.co
 | <a name="input_log_publishing_index_enabled"></a> [log\_publishing\_index\_enabled](#input\_log\_publishing\_index\_enabled) | Specifies whether log publishing option for INDEX\_SLOW\_LOGS is enabled or not | `bool` | `false` | no |
 | <a name="input_log_publishing_search_cloudwatch_log_group_arn"></a> [log\_publishing\_search\_cloudwatch\_log\_group\_arn](#input\_log\_publishing\_search\_cloudwatch\_log\_group\_arn) | ARN of the CloudWatch log group to which log for SEARCH\_SLOW\_LOGS needs to be published | `string` | `""` | no |
 | <a name="input_log_publishing_search_enabled"></a> [log\_publishing\_search\_enabled](#input\_log\_publishing\_search\_enabled) | Specifies whether log publishing option for SEARCH\_SLOW\_LOGS is enabled or not | `bool` | `false` | no |
+| <a name="input_multi_az_with_standby_enabled"></a> [multi\_az\_with\_standby\_enabled](#input\_multi\_az\_with\_standby\_enabled) | Enable domain with standby for OpenSearch cluster | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
 | <a name="input_node_to_node_encryption_enabled"></a> [node\_to\_node\_encryption\_enabled](#input\_node\_to\_node\_encryption\_enabled) | Whether to enable node-to-node encryption | `bool` | `false` | no |

--- a/opensearch_domain.tf
+++ b/opensearch_domain.tf
@@ -47,15 +47,16 @@ resource "aws_opensearch_domain" "default" {
   }
 
   cluster_config {
-    instance_count           = var.instance_count
-    instance_type            = var.instance_type
-    dedicated_master_enabled = var.dedicated_master_enabled
-    dedicated_master_count   = var.dedicated_master_count
-    dedicated_master_type    = var.dedicated_master_type
-    zone_awareness_enabled   = var.zone_awareness_enabled
-    warm_enabled             = var.warm_enabled
-    warm_count               = var.warm_enabled ? var.warm_count : null
-    warm_type                = var.warm_enabled ? var.warm_type : null
+    instance_count                = var.instance_count
+    instance_type                 = var.instance_type
+    dedicated_master_enabled      = var.dedicated_master_enabled
+    dedicated_master_count        = var.dedicated_master_count
+    dedicated_master_type         = var.dedicated_master_type
+    multi_az_with_standby_enabled = var.multi_az_with_standby_enabled
+    zone_awareness_enabled        = var.zone_awareness_enabled
+    warm_enabled                  = var.warm_enabled
+    warm_count                    = var.warm_enabled ? var.warm_count : null
+    warm_type                     = var.warm_enabled ? var.warm_type : null
 
     dynamic "zone_awareness_config" {
       for_each = var.availability_zone_count > 1 && var.zone_awareness_enabled ? [true] : []

--- a/variables.tf
+++ b/variables.tf
@@ -141,6 +141,12 @@ variable "availability_zone_count" {
   }
 }
 
+variable "multi_az_with_standby_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable domain with standby for OpenSearch cluster"
+}
+
 variable "ebs_volume_size" {
   type        = number
   description = "EBS volumes for data storage in GB"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.15.0"
     }
   }
 }


### PR DESCRIPTION
feat: support `multi_az_with_standby_enabled` for opensearch

Note that this bumps the minimum `hashicorp/aws` provider version to
5.15.0, where this parameter was introduced [[1]].

The README diff was generated with `make init` and `make readme`, and
introduces some minor unrelated changes.

[1]: https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5150-august-31-2023
Closes: https://github.com/cloudposse/terraform-aws-elasticsearch/issues/195

---


## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

This PR simply exposes a new variable (`multi_az_with_standby_enabled`) for OpenSearch clusters.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

This is the recommended setting by AWS, so it makes sense to be able to do this via terraform.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

Closes: #195
