### PR TITLE
Provide support for using custom domain name

### DIFF
--- a/elasticsearch_domain.tf
+++ b/elasticsearch_domain.tf
@@ -4,13 +4,13 @@
 
 resource "aws_elasticsearch_domain_policy" "default" {
   count           = local.elasticsearch_enabled && (length(var.iam_authorizing_role_arns) > 0 || length(var.iam_role_arns) > 0) ? 1 : 0
-  domain_name     = module.this.id
+  domain_name     = var.elasticsearch_domain_name != "" ? var.elasticsearch_domain_name : module.this.id
   access_policies = join("", data.aws_iam_policy_document.default[*].json)
 }
 
 resource "aws_elasticsearch_domain" "default" {
   count                 = local.elasticsearch_enabled ? 1 : 0
-  domain_name           = module.this.id
+  domain_name           = var.elasticsearch_domain_name != "" ? var.elasticsearch_domain_name : module.this.id
   elasticsearch_version = var.elasticsearch_version
 
   advanced_options = var.advanced_options

--- a/opensearch_domain.tf
+++ b/opensearch_domain.tf
@@ -4,13 +4,13 @@
 
 resource "aws_opensearch_domain_policy" "default" {
   count           = local.opensearch_enabled && (length(var.iam_authorizing_role_arns) > 0 || length(var.iam_role_arns) > 0) ? 1 : 0
-  domain_name     = module.this.id
+  domain_name     = var.elasticsearch_domain_name != "" ? var.elasticsearch_domain_name : module.this.id
   access_policies = join("", data.aws_iam_policy_document.default[*].json)
 }
 
 resource "aws_opensearch_domain" "default" {
   count          = local.opensearch_enabled ? 1 : 0
-  domain_name    = module.this.id
+  domain_name    = var.elasticsearch_domain_name != "" ? var.elasticsearch_domain_name : module.this.id
   engine_version = var.elasticsearch_version
 
   advanced_options = var.advanced_options

--- a/variables.tf
+++ b/variables.tf
@@ -268,6 +268,22 @@ variable "advanced_options" {
   description = "Key-value string pairs to specify advanced configuration options"
 }
 
+variable "elasticsearch_domain_name" {
+  type        = string
+  default     = ""
+  description = "The name of the Elasticsearch domain. Must be at least 3 and no more than 28 characters long. Valid characters are a-z (lowercase letters), 0-9, and - (hyphen)."
+
+  validation {
+    condition     = length(var.elasticsearch_domain_name) >= 3 && length(var.elasticsearch_domain_name) <= 28
+    error_message = "The elasticsearch_domain_name must be at least 3 and no more than 28 characters long."
+  }
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.elasticsearch_domain_name))
+    error_message = "The elasticsearch_domain_name can only contain lowercase letters (a-z), numbers (0-9), and hyphens (-), and cannot start with a hyphen."
+  }
+}
+
 variable "elasticsearch_subdomain_name" {
   type        = string
   default     = ""
@@ -447,4 +463,3 @@ variable "auto_tune" {
     error_message = "Variable auto_tune.rollback_on_disable valid values: DEFAULT_ROLLBACK or NO_ROLLBACK."
   }
 }
-


### PR DESCRIPTION
Provide support for using custom domain name as a fix for this limit: the domain name has a limit of 3-28 characters.