### PR TITLE
Add throughput to ebs_options for OpenSearch

### DIFF
--- a/opensearch_domain.tf
+++ b/opensearch_domain.tf
@@ -31,6 +31,7 @@ resource "aws_opensearch_domain" "default" {
     volume_size = var.ebs_volume_size
     volume_type = var.ebs_volume_type
     iops        = var.ebs_iops
+    throughput  = var.ebs_throughput
   }
 
   encrypt_at_rest {


### PR DESCRIPTION
## what

- Fix ebs_throughput in aws_opensearch_domain by adding throughput to ebs_options

## why

- Fix for https://github.com/cloudposse/terraform-aws-elasticsearch/issues/208
- Makes it possible to configure ebs_throughput on an OpenSearch domain

## references

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearch_domain
