### PR TITLE
create user even if only needed for irsa

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ resource "aws_iam_service_linked_role" "default" {
 
 # Role that pods can assume for access to elasticsearch and kibana
 resource "aws_iam_role" "elasticsearch_user" {
-  count              = module.this.enabled && var.create_elasticsearch_user_role && (length(var.iam_authorizing_role_arns) > 0 || length(var.iam_role_arns) > 0) ? 1 : 0
+  count              = module.this.enabled && var.create_elasticsearch_user_role && (length(var.iam_authorizing_role_arns) > 0 || length(var.iam_role_arns) > 0 || var.iam_irsa_openid_connect_provider_arn != "") ? 1 : 0
   name               = module.user_label.id
   assume_role_policy = join("", data.aws_iam_policy_document.assume_role[*].json)
   description        = "IAM Role to assume to access the Elasticsearch ${module.this.id} cluster"
@@ -95,7 +95,7 @@ resource "aws_iam_role" "elasticsearch_user" {
 }
 
 data "aws_iam_policy_document" "assume_role" {
-  count = module.this.enabled && var.create_elasticsearch_user_role && (length(var.iam_authorizing_role_arns) > 0 || length(var.iam_role_arns) > 0) ? 1 : 0
+  count = module.this.enabled && var.create_elasticsearch_user_role && (length(var.iam_authorizing_role_arns) > 0 || length(var.iam_role_arns) > 0 || var.iam_irsa_openid_connect_provider_arn != "") ? 1 : 0
 
   statement {
     actions = [
@@ -151,7 +151,7 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 data "aws_iam_policy_document" "default" {
-  count = module.this.enabled && (length(var.iam_authorizing_role_arns) > 0 || length(var.iam_role_arns) > 0) ? 1 : 0
+  count = module.this.enabled && (length(var.iam_authorizing_role_arns) > 0 || length(var.iam_role_arns) > 0 || var.iam_irsa_openid_connect_provider_arn != "") ? 1 : 0
 
   statement {
     sid = "User"

--- a/opensearch_domain.tf
+++ b/opensearch_domain.tf
@@ -3,7 +3,7 @@
 #
 
 resource "aws_opensearch_domain_policy" "default" {
-  count           = local.opensearch_enabled && (length(var.iam_authorizing_role_arns) > 0 || length(var.iam_role_arns) > 0) ? 1 : 0
+  count           = local.opensearch_enabled && (length(var.iam_authorizing_role_arns) > 0 || length(var.iam_role_arns) > 0 || var.iam_irsa_openid_connect_provider_arn != "") ? 1 : 0
   domain_name     = length(var.elasticsearch_domain_name) > 0 ? var.elasticsearch_domain_name : module.this.id
   access_policies = join("", data.aws_iam_policy_document.default[*].json)
 }


### PR DESCRIPTION
## what

- let user role be created even if iam_authorizing_role_arns and iam_role_arns are not set if needed for irsa

## why

- currently you need to add iam_authorizing_role_arns or iam_role_arns event if you don't need it to get the role created

