### PR TITLE
fix: conditionally set service domain outputs when disabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,11 +4,11 @@ locals {
 
   service_linked_role_name = local.elasticsearch_enabled ? "AWSServiceRoleForAmazonElasticsearchService" : "AWSServiceRoleForAmazonOpenSearchService"
 
-  aws_service_domain_arn             = coalesce(join("", aws_elasticsearch_domain.default[*].arn), join("", aws_opensearch_domain.default[*].arn))
-  aws_service_domain_endpoint        = coalesce(join("", aws_elasticsearch_domain.default[*].endpoint), join("", aws_opensearch_domain.default[*].endpoint))
-  aws_service_domain_id              = coalesce(join("", aws_elasticsearch_domain.default[*].domain_id), join("", aws_opensearch_domain.default[*].domain_id))
-  aws_service_domain_name            = coalesce(join("", aws_elasticsearch_domain.default[*].domain_name), join("", aws_opensearch_domain.default[*].domain_name))
-  aws_service_domain_kibana_endpoint = coalesce(join("", aws_elasticsearch_domain.default[*].kibana_endpoint), join("", aws_opensearch_domain.default[*].dashboard_endpoint))
+  aws_service_domain_arn             = module.this.enabled ? coalesce(join("", aws_elasticsearch_domain.default[*].arn), join("", aws_opensearch_domain.default[*].arn)) : null
+  aws_service_domain_endpoint        = module.this.enabled ? coalesce(join("", aws_elasticsearch_domain.default[*].endpoint), join("", aws_opensearch_domain.default[*].endpoint)) : null
+  aws_service_domain_id              = module.this.enabled ? coalesce(join("", aws_elasticsearch_domain.default[*].domain_id), join("", aws_opensearch_domain.default[*].domain_id)) : null
+  aws_service_domain_name            = module.this.enabled ? coalesce(join("", aws_elasticsearch_domain.default[*].domain_name), join("", aws_opensearch_domain.default[*].domain_name)) : null
+  aws_service_domain_kibana_endpoint = module.this.enabled ? coalesce(join("", aws_elasticsearch_domain.default[*].kibana_endpoint), join("", aws_opensearch_domain.default[*].dashboard_endpoint)) : null
 }
 
 module "user_label" {


### PR DESCRIPTION
## what

- Previously, service domain output locals were always set, even when the module was disabled. This caused issues with downstream references. Now, these locals are set to null when the module is not enabled, preventing unintended values and improving conditional logic handling.

## why

- Resolve the following error:

```console
╷
│ Error: Error in function call
│
│   on .terraform/infra/modules/elasticsearch/main.tf line 11, in locals:
│   11:   aws_service_domain_kibana_endpoint = coalesce(join("", aws_elasticsearch_domain.default[*].kibana_endpoint), join("", aws_opensearch_domain.default[*].dashboard_endpoint))
│     ├────────────────
│     │ while calling coalesce(vals...)
│     │ aws_elasticsearch_domain.default is empty tuple
│     │ aws_opensearch_domain.default is empty tuple
│
│ Call to function "coalesce" failed: no non-null, non-empty-string arguments.
╵
```

- Closes #193 
