### PR TITLE
Upgrade OpenSearch version to 3.1

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -12,7 +12,7 @@ module "elasticsearch" {
   vpc_id                  = "vpc-XXXXXXXXX"
   subnet_ids              = ["subnet-XXXXXXXXX", "subnet-YYYYYYYY"]
   zone_awareness_enabled  = "true"
-  elasticsearch_version   = "6.5"
+  elasticsearch_version   = "7.10"
   instance_type           = "t2.small.elasticsearch"
   instance_count          = 4
   ebs_volume_size         = 10

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -12,7 +12,7 @@ availability_zones = ["us-east-2a", "us-east-2b"]
 
 instance_type = "t3.small.elasticsearch"
 
-elasticsearch_version = "7.7"
+elasticsearch_version = "7.10"
 
 instance_count = 2
 

--- a/examples/non_vpc/main.tf
+++ b/examples/non_vpc/main.tf
@@ -11,7 +11,7 @@ module "elasticsearch" {
   security_groups         = ["sg-XXXXXXXXX", "sg-YYYYYYYY"]
   vpc_enabled             = false
   zone_awareness_enabled  = "true"
-  elasticsearch_version   = "6.5"
+  elasticsearch_version   = "7.10"
   instance_type           = "t2.small.elasticsearch"
   instance_count          = 4
   iam_role_arns           = ["arn:aws:iam::XXXXXXXXX:role/ops", "arn:aws:iam::XXXXXXXXX:role/dev"]

--- a/examples/opensearch_basic/main.tf
+++ b/examples/opensearch_basic/main.tf
@@ -13,7 +13,7 @@ module "opensearch" {
   subnet_ids              = ["subnet-XXXXXXXXX", "subnet-YYYYYYYY"]
   zone_awareness_enabled  = "true"
   aws_service_type        = "opensearch"
-  elasticsearch_version   = "OpenSearch_2.9"
+  elasticsearch_version   = "OpenSearch_3.1"
   instance_type           = "t3.small.search"
   instance_count          = 4
   ebs_volume_size         = 10

--- a/variables.tf
+++ b/variables.tf
@@ -60,7 +60,7 @@ variable "dns_zone_id" {
 
 variable "elasticsearch_version" {
   type        = string
-  default     = "7.4"
+  default     = "7.10"
   description = "Version of Elasticsearch to deploy (_e.g._ `7.4`, `7.1`, `6.8`, `6.7`, `6.5`, `6.4`, `6.3`, `6.2`, `6.0`, `5.6`, `5.5`, `5.3`, `5.1`, `2.3`, `1.5`"
 }
 


### PR DESCRIPTION
## what
* Upgrade OpenSearch version to 3.1 in examples
* Upgrade ElasticSearch version to 7.10 in examples

## why
* OpenSearch 2.9 ended the standard support 
* ElasticSearch 7.10 ended the standard support 

## references
- https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html#choosing-version