### PR TITLE
feat: add support for identity_center_options

### DIFF
--- a/examples/opensearch_basic/main.tf
+++ b/examples/opensearch_basic/main.tf
@@ -25,4 +25,11 @@ module "opensearch" {
   advanced_options = {
     "rest.action.multi.allow_explicit_index" = "true"
   }
+
+  identity_center_options = {
+    identity_center_instance_arn = "arn:aws:sso:::instance/ssoins-xxxxxxxxxxxxxxx"
+    subject_key                  = "sub"
+    roles_key                    = "roles"
+    enabled_api_access           = true
+  }
 }

--- a/opensearch_domain.tf
+++ b/opensearch_domain.tf
@@ -26,6 +26,16 @@ resource "aws_opensearch_domain" "default" {
     }
   }
 
+  dynamic "identity_center_options" {
+    for_each = var.identity_center_options != null ? [var.identity_center_options] : []
+    content {
+      enabled_api_access           = identity_center_options.value.enabled_api_access
+      identity_center_instance_arn = identity_center_options.value.identity_center_instance_arn
+      subject_key                  = identity_center_options.value.subject_key
+      roles_key                    = identity_center_options.value.roles_key
+    }
+  }
+
   ebs_options {
     ebs_enabled = var.ebs_volume_size > 0 ? true : false
     volume_size = var.ebs_volume_size

--- a/variables.tf
+++ b/variables.tf
@@ -500,6 +500,18 @@ variable "advanced_security_options_anonymous_auth_enabled" {
   description = "Whether Anonymous auth is enabled. Enables fine-grained access control on an existing domain"
 }
 
+variable "identity_center_options" {
+  type = object({
+    enabled_api_access           = optional(bool, true)
+    identity_center_instance_arn = string
+    subject_key                  = string
+    roles_key                    = string
+  })
+
+  default     = null
+  description = "Configuration block for authenticating AWS IAM Identity Center principals via OpenSearch identity_center_options. Applicable to aws_opensearch_domain only."
+}
+
 variable "access_policies" {
   description = "JSON string for the IAM policy document specifying the access policies for the domain."
   type        = string


### PR DESCRIPTION
## what

Add support for authentication of AWS IAM Identity Center principals.

## why

- Support federated Single Sign On to OpenSearch UI, for example for users of Microsoft Office 365.

## references

- Fixes #222
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearch_domain#identity_center_options
- https://docs.aws.amazon.com/opensearch-service/latest/developerguide/idc-aos.html
- hashicorp/terraform-provider-aws#44626